### PR TITLE
fix: use workspace typescript in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
     {
       "mode": "auto"
     }
-  ]
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }


### PR DESCRIPTION
## 🚀 PR 개요

VSCode에서 `packages/ui`의 tsconfig extends/React 타입 관련 빨간 줄이 발생하는 문제를 재현했으나, CLI(`pnpm -r run check-types`)에서는 정상 통과하여 **코드/설정 자체 문제라기보다 VSCode가 workspace TypeScript를 사용하지 않는 환경 이슈**로 판단

Workspace TypeScript(tsserver)를 강제하도록 `.vscode/settings.json`을 보강해 **모노레포 타입 해석이 안정적으로 동작 확인.**

## 🔗 관련 이슈

- Closes #23

## 🔍 작업 내용

- `.vscode/settings.json`
    - `typescript.tsdk`를 `node_modules/typescript/lib`로 지정
    - `typescript.enablePromptUseWorkspaceTsdk` 활성화
    - (기존 ESLint workingDirectories 설정은 유지)

## ✔ 주요 고민과 해결 과정

- `pnpm -r run check-types`가 모든 패키지에서 통과하는데 VSCode에서만 `react 모듈을 찾을 수 없음`, `-jsx 플래그 필요` 같은 오류가 발생.
- 원인을 **tsserver가 workspace TS를 사용하지 않아 모노레포 패키지 해석이 꼬이는 문제**로 보고, 커맨드 팔레트 없이도 강제 적용 가능한 `.vscode/settings.json` 기반 해결을 선택.
- 적용 후 `node_modules/typescript/lib/tsserver.js` 존재 확인 및 VSCode 오류 해소를 확인.

## 📝 참고문서, 학습정리(선택)

- pnpm workspace에서는 VSCode가 전역 TypeScript를 사용할 경우 패키지 해석이 흔들릴 수 있어 `typescript.tsdk` 고정이 유효.

## 기타
- 별도 캐시 삭제 없이도 설정 적용 + VSCode 재시작으로 문제 해소 확인
