### PR TITLE
[Fix] 타입 import 수정

### DIFF
--- a/apps/web/src/api/internal/now-playlist.ts
+++ b/apps/web/src/api/internal/now-playlist.ts
@@ -1,15 +1,15 @@
 // src/api/internal/now-playlist.ts
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 import { internalClient } from './client';
 
 // [GET] 재생 목록 가져오기
-export const getNowPlaylist = async (): Promise<MusicResponseDto[]> => {
-  const { data } = await internalClient.get<{ musics: MusicResponseDto[] }>('/nowPlaylist');
+export const getNowPlaylist = async (): Promise<Music[]> => {
+  const { data } = await internalClient.get<{ musics: Music[] }>('/nowPlaylist');
   return data.musics;
 };
 
 // [PUT] 재생 목록 업데이트 (순서 변경, 추가, 삭제 등)
-export const updateNowPlaylist = async (playlist: MusicResponseDto[]): Promise<void> => {
+export const updateNowPlaylist = async (playlist: Music[]): Promise<void> => {
   const musicIds = playlist.map((m) => m.id);
   await internalClient.put('/nowPlaylist', { musicIds });
 };

--- a/apps/web/src/components/feed/FeedList.tsx
+++ b/apps/web/src/components/feed/FeedList.tsx
@@ -3,10 +3,10 @@
 import { usePlayerStore } from '@/stores';
 import { useModalStore, MODAL_TYPES } from '@/stores/useModalStore';
 import { PostCard } from '@/components';
-import { MusicResponseDto, PostResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music, PostResponseDto as Post } from '@repo/dto';
 
 interface FeedListProps {
-  posts: PostResponseDto[];
+  posts: Post[];
 }
 
 export default function FeedList({ posts }: FeedListProps) {
@@ -16,7 +16,7 @@ export default function FeedList({ posts }: FeedListProps) {
 
   const openModal = useModalStore((s) => s.openModal);
 
-  const handlePlay = (music: MusicResponseDto) => {
+  const handlePlay = (music: Music) => {
     playMusic(music);
   };
 
@@ -25,7 +25,7 @@ export default function FeedList({ posts }: FeedListProps) {
     void userId;
   };
 
-  const handleOpenDetail = (post: PostResponseDto) => {
+  const handleOpenDetail = (post: Post) => {
     openModal(MODAL_TYPES.POST_DETAIL, { postId: post.id, post });
   };
 

--- a/apps/web/src/components/modals/ContentWriteModal/ContentWriteModal.tsx
+++ b/apps/web/src/components/modals/ContentWriteModal/ContentWriteModal.tsx
@@ -6,14 +6,14 @@ import { Playlist } from '@/types';
 import { CoverImgUploader } from './CoverImgUploader';
 import { MusicSearch } from './MusicSearch';
 import { SelectedMusicList } from './SelectedMusicList';
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 import { DEFAULT_IMGAES } from '@/constants/defaultImages';
 
-export const ContentWriteModal = ({ initialMusic }: { initialMusic?: MusicResponseDto }) => {
+export const ContentWriteModal = ({ initialMusic }: { initialMusic?: Music }) => {
   const { closeModal } = useModalStore();
 
   // --- 지역상태 관리 ---
-  const [selectedMusics, setSelectedMusics] = useState<MusicResponseDto[]>(initialMusic ? [initialMusic] : []);
+  const [selectedMusics, setSelectedMusics] = useState<Music[]>(initialMusic ? [initialMusic] : []);
   const [content, setContent] = useState('');
 
   const [customCoverPreview, setCustomCoverPreview] = useState<string | null>(null);
@@ -81,7 +81,7 @@ export const ContentWriteModal = ({ initialMusic }: { initialMusic?: MusicRespon
   };
 
   // 음악 추가
-  const handleAddMusic = (music: MusicResponseDto) => {
+  const handleAddMusic = (music: Music) => {
     // 중복 체크
     if (!selectedMusics.find((m) => m.id === music.id)) {
       setSelectedMusics([...selectedMusics, music]);

--- a/apps/web/src/components/modals/ContentWriteModal/MusicSearch.tsx
+++ b/apps/web/src/components/modals/ContentWriteModal/MusicSearch.tsx
@@ -6,7 +6,7 @@ import type { Playlist } from '@/types';
 import { searchItunesSongs } from '@/api';
 import { itunesSongToMusic } from '@/mappers';
 import { useDebouncedValue } from '@/hooks';
-import { MusicProvider, MusicResponseDto } from '@repo/dto';
+import { MusicProvider, MusicResponseDto as Music } from '@repo/dto';
 
 type SearchStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
 
@@ -16,7 +16,7 @@ const DEFAULT_LIMIT = 20;
 const COUNTRY: 'KR' = 'KR';
 
 // 목업 데이터 | 음악, {내 플레이리스트}
-const MOCK_MUSICS: MusicResponseDto[] = [
+const MOCK_MUSICS: Music[] = [
   {
     id: '11111111-1111-1111-1111-111111111111',
     title: 'we cant be friends',
@@ -70,7 +70,7 @@ interface MusicSearchProps {
   setSearchQuery: (query: string) => void;
   isSearchOpen: boolean;
   setIsSearchOpen: (isOpen: boolean) => void;
-  onAddMusic: (music: MusicResponseDto) => void;
+  onAddMusic: (music: Music) => void;
   onAddPlaylist: (playlist: Playlist) => void;
 }
 
@@ -80,7 +80,7 @@ export const MusicSearch = ({ searchQuery, setSearchQuery, isSearchOpen, setIsSe
 
   const [status, setStatus] = useState<SearchStatus>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [results, setResults] = useState<MusicResponseDto[]>([]);
+  const [results, setResults] = useState<Music[]>([]);
 
   const abortRef = useRef<AbortController | null>(null);
 
@@ -174,7 +174,7 @@ export const MusicSearch = ({ searchQuery, setSearchQuery, isSearchOpen, setIsSe
     onAddPlaylist(playlist);
   };
 
-  const handleAddMusicClick = (music: MusicResponseDto) => {
+  const handleAddMusicClick = (music: Music) => {
     onAddMusic(music);
   };
 

--- a/apps/web/src/components/modals/ContentWriteModal/SelectedMusicList.tsx
+++ b/apps/web/src/components/modals/ContentWriteModal/SelectedMusicList.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { ChevronUp, ChevronDown, Trash2, Music as MusicIcon } from 'lucide-react';
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 
 interface SelectedMusicListProps {
-  musics: MusicResponseDto[];
+  musics: Music[];
   onRemove: (id: string) => void;
   onMove: (index: number, direction: 'up' | 'down') => void;
 }

--- a/apps/web/src/components/modals/MobilePlayerModal/MobilePlayerModal.tsx
+++ b/apps/web/src/components/modals/MobilePlayerModal/MobilePlayerModal.tsx
@@ -3,16 +3,16 @@
 import { X, Trash2, ChevronUp, ChevronDown, XCircle, ListPlus } from 'lucide-react';
 import { useModalStore, MODAL_TYPES } from '@/stores/useModalStore';
 import { usePlayerStore } from '@/stores';
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 
 type MobileQueueRowProps = {
-  music: MusicResponseDto;
+  music: Music;
   index: number;
   isCurrent: boolean;
   isFirst: boolean;
   isLast: boolean;
 
-  onPlay: (music: MusicResponseDto) => void;
+  onPlay: (music: Music) => void;
   onRemove: (musicId: string) => void;
   onMoveUp: (index: number) => void;
   onMoveDown: (index: number) => void;

--- a/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx
+++ b/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx
@@ -8,7 +8,7 @@ import { useScrollLock } from '@/hooks';
 import { formatRelativeTime } from '@/utils';
 import { buildMockComments, EMPTY_POST } from '@/constants';
 import { PostMedia, LoadingSpinner } from '@/components';
-import { MusicResponseDto, PostResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music, PostResponseDto as Post } from '@repo/dto';
 
 export const PostCardDetailModal = () => {
   const { isOpen, modalType, modalProps, closeModal } = useModalStore();
@@ -24,7 +24,7 @@ export const PostCardDetailModal = () => {
 
   // postId를 단일 진실로 사용
   const postId = enabled ? (modalProps?.postId as string | undefined) : undefined;
-  const passedPost = enabled ? ((modalProps?.post as PostResponseDto | undefined) ?? undefined) : undefined;
+  const passedPost = enabled ? ((modalProps?.post as Post | undefined) ?? undefined) : undefined;
 
   // post가 있더라도 postId와 일치할 때만 신뢰
   const matchedPost = postId && passedPost?.id === postId ? passedPost : undefined;
@@ -49,7 +49,7 @@ export const PostCardDetailModal = () => {
     e.stopPropagation();
   };
 
-  const handlePlay = (music: MusicResponseDto) => {
+  const handlePlay = (music: Music) => {
     playMusic(music);
   };
 

--- a/apps/web/src/components/player/MiniPlayerBar.tsx
+++ b/apps/web/src/components/player/MiniPlayerBar.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 import { FolderPlus, Pause, Play, PlusCircle, SkipBack, SkipForward, ListPlus } from 'lucide-react';
 
 interface MiniPlayerBarProps {
-  currentMusic: MusicResponseDto | null;
+  currentMusic: Music | null;
   isPlaying: boolean;
 
   canPrev: boolean;

--- a/apps/web/src/components/player/NowPlaying.tsx
+++ b/apps/web/src/components/player/NowPlaying.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 import { Pause, Play, Shuffle, SkipBack, SkipForward, Repeat, PlusCircle, FolderPlus } from 'lucide-react';
 import { useMemo } from 'react';
 
 interface NowPlayingProps {
-  currentMusic: MusicResponseDto | null;
+  currentMusic: Music | null;
   isPlaying: boolean;
 
   canPrev: boolean;

--- a/apps/web/src/components/player/QueueList.tsx
+++ b/apps/web/src/components/player/QueueList.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 import { Box, Plus, ListPlus, Trash2, ChevronUp, ChevronDown, XCircle } from 'lucide-react';
 
 interface QueueListProps {
-  queue: MusicResponseDto[];
+  queue: Music[];
   currentMusicId: string | null;
   onClear: () => void;
   onRemove: (musicId: string) => void;
@@ -12,7 +12,7 @@ interface QueueListProps {
   onMoveDown: (index: number) => void;
 
   /** 추가: 큐 아이템 선택(현재 재생 곡 변경) */
-  onSelect: (music: MusicResponseDto) => void;
+  onSelect: (music: Music) => void;
 }
 
 const DISABLED_ACTION_TITLE = '추후 연결 예정';

--- a/apps/web/src/components/post/PostCard.tsx
+++ b/apps/web/src/components/post/PostCard.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import { PostHeader, PostMedia, PostActions, PostContentPreview } from './index';
-import { MusicResponseDto, PostResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music, PostResponseDto as Post } from '@repo/dto';
 
 interface PostCardProps {
-  post: PostResponseDto;
+  post: Post;
 
   currentMusicId: string | null;
   isPlayingGlobal: boolean;
 
-  onPlay: (music: MusicResponseDto) => void;
+  onPlay: (music: Music) => void;
   onUserClick: (userId: string) => void;
-  onOpenDetail: (post: PostResponseDto) => void;
+  onOpenDetail: (post: Post) => void;
 }
 
 export default function PostCard({ post, currentMusicId, isPlayingGlobal, onPlay, onUserClick, onOpenDetail }: PostCardProps) {

--- a/apps/web/src/components/post/PostMedia.tsx
+++ b/apps/web/src/components/post/PostMedia.tsx
@@ -2,18 +2,18 @@
 
 import { ChevronLeft, ChevronRight, Pause, Play } from 'lucide-react';
 import { usePostMedia } from '@/hooks';
-import { MusicResponseDto, PostResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music, PostResponseDto as Post } from '@repo/dto';
 
 type Variant = 'card' | 'modal';
 
 type Props = {
-  post: PostResponseDto;
+  post: Post;
   variant: Variant;
 
   currentMusicId: string | null;
   isPlayingGlobal: boolean;
 
-  onPlay: (music: MusicResponseDto) => void;
+  onPlay: (music: Music) => void;
 
   /** 카드에서만: 컨테이너 클릭 시 상세 열기 */
   onClickContainer?: () => void;

--- a/apps/web/src/components/search/SearchDrawerContent.tsx
+++ b/apps/web/src/components/search/SearchDrawerContent.tsx
@@ -8,7 +8,7 @@ import { SearchInput, SearchStateMessage, TrackItem } from './index';
 import { useDebouncedValue, useMusicActions } from '@/hooks';
 import { searchItunesSongs } from '@/api';
 import { itunesSongToMusic } from '@/mappers';
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 
 type SearchStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
 
@@ -23,7 +23,7 @@ function SearchDrawerInner() {
 
   const [status, setStatus] = useState<SearchStatus>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [results, setResults] = useState<MusicResponseDto[]>([]);
+  const [results, setResults] = useState<Music[]>([]);
   const [openPreviewMusicId, setOpenPreviewMusicId] = useState<string | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);

--- a/apps/web/src/components/search/TrackItem.tsx
+++ b/apps/web/src/components/search/TrackItem.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 import { Box, Play, PlusCircle } from 'lucide-react';
 
 interface TrackItemProps {
-  music: MusicResponseDto;
+  music: Music;
 
   /** 보관함/작성 등 후속 이슈에서 연결 */
   disabledActions?: boolean;
 
-  onPlay?: (music: MusicResponseDto) => void;
-  onAddToArchive?: (music: MusicResponseDto) => void;
-  onOpenWrite?: (music: MusicResponseDto) => void;
+  onPlay?: (music: Music) => void;
+  onAddToArchive?: (music: Music) => void;
+  onOpenWrite?: (music: Music) => void;
 }
 
 const DISABLED_ACTION_TITLE = '추후 연결 예정';

--- a/apps/web/src/constants/mockPosts.ts
+++ b/apps/web/src/constants/mockPosts.ts
@@ -1,4 +1,4 @@
-import { MusicProvider, MusicResponseDto, PostResponseDto } from '@repo/dto';
+import { MusicProvider, MusicResponseDto as Music, PostResponseDto as Post } from '@repo/dto';
 
 const now = Date.now();
 const minutes = (n: number) => n * 60 * 1000;
@@ -7,7 +7,7 @@ const days = (n: number) => n * 24 * 60 * 60 * 1000;
 
 const isoAgo = (msAgo: number) => new Date(now - msAgo).toISOString();
 
-const MOCK_MUSICS: MusicResponseDto[] = [
+const MOCK_MUSICS: Music[] = [
   {
     id: 'm-1',
     provider: MusicProvider.ITUNES,
@@ -82,7 +82,7 @@ const USER_3 = {
   profileImgUrl: 'https://picsum.photos/seed/user-3/100/100',
 };
 
-export const MOCK_POSTS: PostResponseDto[] = [
+export const MOCK_POSTS: Post[] = [
   {
     id: 'p-1',
     author: USER_1,

--- a/apps/web/src/hooks/useGuestQueueSession.ts
+++ b/apps/web/src/hooks/useGuestQueueSession.ts
@@ -2,14 +2,14 @@
 
 import { useEffect, useRef } from 'react';
 import { usePlayerStore } from '@/stores';
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 
 const STORAGE_KEY = 'guest_queue_v1';
 const SAVE_DEBOUNCE_MS = 500;
 
 type StoredGuestQueue = {
-  queue: MusicResponseDto[];
-  currentMusic: MusicResponseDto | null;
+  queue: Music[];
+  currentMusic: Music | null;
   isPlaying: boolean;
   savedAt: number;
 };

--- a/apps/web/src/hooks/useMusicActions.ts
+++ b/apps/web/src/hooks/useMusicActions.ts
@@ -1,20 +1,20 @@
 'use client';
 
 import { MODAL_TYPES, useModalStore, usePlayerStore } from '@/stores';
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 
 export default function useMusicActions() {
   const playMusic = usePlayerStore((s) => s.playMusic);
   const openModal = useModalStore((s) => s.openModal);
 
   /** 현재 플레이리스트에 음악 저장 함수 (검색 결과의 음악 재생 버튼, 피드 게시물 클릭 시 사용) */
-  const addMusicToPlayer = (track: MusicResponseDto) => playMusic(track);
+  const addMusicToPlayer = (track: Music) => playMusic(track);
 
   /** 음악으로 컨텐츠 작성 모달 오픈 함수 */
-  const openWriteModalWithMusic = (track: MusicResponseDto) => openModal(MODAL_TYPES.WRITE, { initialMusic: track });
+  const openWriteModalWithMusic = (track: Music) => openModal(MODAL_TYPES.WRITE, { initialMusic: track });
 
   /** TODO: 보관함에 음악 저장 함수 */
-  const addMusicToArchive = (track: MusicResponseDto, playlistId: string) => {};
+  const addMusicToArchive = (track: Music, playlistId: string) => {};
 
   return {
     addMusicToPlayer,

--- a/apps/web/src/hooks/usePostMedia.ts
+++ b/apps/web/src/hooks/usePostMedia.ts
@@ -1,10 +1,10 @@
 'use client';
 
 import { useCallback, useMemo, useState } from 'react';
-import { MusicResponseDto, PostResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music, PostResponseDto as Post } from '@repo/dto';
 
 type Args = {
-  post: PostResponseDto;
+  post: Post;
   currentMusicId: string | null;
   isPlayingGlobal: boolean;
 };
@@ -14,7 +14,7 @@ export function usePostMedia({ post, currentMusicId, isPlayingGlobal }: Args) {
 
   const isMulti = post.musics.length > 1;
 
-  const activeMusic = useMemo<MusicResponseDto | null>(() => post.musics[activeIndex] ?? null, [post.musics, activeIndex]);
+  const activeMusic = useMemo<Music | null>(() => post.musics[activeIndex] ?? null, [post.musics, activeIndex]);
   const coverUrl = activeMusic?.albumCoverUrl ?? post.coverImgUrl;
 
   const isActivePlaying = Boolean(activeMusic && isPlayingGlobal && currentMusicId === activeMusic.id);

--- a/apps/web/src/mappers/itunesSongToMusic.ts
+++ b/apps/web/src/mappers/itunesSongToMusic.ts
@@ -1,5 +1,5 @@
 import type { ItunesSongResult } from '@/api';
-import { MusicProvider, MusicResponseDto } from '@repo/dto';
+import { MusicProvider, MusicResponseDto as Music } from '@repo/dto';
 
 const FALLBACK_COVER_URL = 'https://via.placeholder.com/400?text=No+Cover';
 
@@ -15,7 +15,7 @@ const toHighResArtworkUrl = (artworkUrl100?: string): string => {
  * - iTunes(APPLE) provider에서는 `trackUri` 필드에 previewUrl(30초 미리듣기 URL)을 저장합니다.
  * - 실제 음원 재생(전체 재생)은 별도 설계가 필요하므로, 지금 단계에서는 preview 기준으로 통일합니다.
  */
-export const itunesSongToMusic = (track: ItunesSongResult): MusicResponseDto => {
+export const itunesSongToMusic = (track: ItunesSongResult): Music => {
   return {
     id: track.trackId.toString(),
     provider: MusicProvider.ITUNES,

--- a/apps/web/src/mappers/spotifyTrackToMusic.ts
+++ b/apps/web/src/mappers/spotifyTrackToMusic.ts
@@ -1,5 +1,5 @@
 import type { SpotifyTrack } from '@/api';
-import { MusicProvider, MusicResponseDto } from '@repo/dto';
+import { MusicProvider, MusicResponseDto as Music } from '@repo/dto';
 
 const joinArtistNames = (artists: { name: string }[]): string =>
   artists
@@ -12,7 +12,7 @@ const pickAlbumCoverUrl = (track: SpotifyTrack): string => {
   return first?.url ?? 'https://via.placeholder.com/400?text=No+Cover';
 };
 
-export const spotifyTrackToMusic = (track: SpotifyTrack): MusicResponseDto => ({
+export const spotifyTrackToMusic = (track: SpotifyTrack): Music => ({
   // NOTE: DB UUID는 서버 저장 시 생성. 검색 결과 단계에서는 Spotify track id를 임시 key로 사용.
   id: track.id,
   trackUri: track.uri,

--- a/apps/web/src/types/player.ts
+++ b/apps/web/src/types/player.ts
@@ -1,11 +1,11 @@
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 
 export interface NowPlayingState {
-  currentMusic: MusicResponseDto | null;
+  currentMusic: Music | null;
   isPlaying: boolean;
 }
 
 export interface QueueItem {
-  music: MusicResponseDto;
+  music: Music;
   orderIndex: number;
 }

--- a/apps/web/src/types/playlist.ts
+++ b/apps/web/src/types/playlist.ts
@@ -1,7 +1,7 @@
-import { MusicResponseDto } from '@repo/dto';
+import { MusicResponseDto as Music } from '@repo/dto';
 
 export interface Playlist {
   playlistId: string;
   title: string;
-  musics: MusicResponseDto[];
+  musics: Music[];
 }


### PR DESCRIPTION
## 🚀 PR 개요

- 프론트에서 삭제된 Music 타입을 import 하던 것을 dto의 MusicResponseDto를 import 하도록 수정 - 이전 PR에서 놓쳤던 부분이 있어서 수정했습니다.
- 프론트에서 MusicResponseDto, PostResponseDto를 import 할 때는 이름을 바꿔서 Music, Post라는 이름으로 사용되도록 수정했습니다.

## 기타

import해서 작업할실 때에 그냥 import해서 사용해도 되고 위에 말한것처럼 이름 바꿔서 import해도 되는데 자유롭게 하시면 될 듯 합니다.