### PR TITLE
fix: 유저 프로필조회 기능 카운트가 작동하지 않는 문제 수정

### DIFF
--- a/apps/api/src/modules/follow/follow.repository.ts
+++ b/apps/api/src/modules/follow/follow.repository.ts
@@ -134,4 +134,22 @@ export class FollowRepository {
 
     return follows.map((follow) => follow.followedUserId);
   }
+
+  // 특정 유저의 팔로우 수
+  async countFollowing(userId: string): Promise<number> {
+    return this.repository.count({
+      where: {
+        followingUserId: userId,
+      },
+    });
+  }
+
+  // 특정 유저의 팔로워 수
+  async countFollowers(userId: string): Promise<number> {
+    return this.repository.count({
+      where: {
+        followedUserId: userId,
+      },
+    });
+  }
 }

--- a/apps/api/src/modules/follow/follow.service.ts
+++ b/apps/api/src/modules/follow/follow.service.ts
@@ -162,4 +162,14 @@ export class FollowService {
       nextCursor,
     };
   }
+
+  async countFollow(userId: string) {
+    const follower = await this.followRepository.countFollowers(userId);
+    const following = await this.followRepository.countFollowing(userId);
+
+    return {
+      followerCount: follower,
+      followingCount: following,
+    };
+  }
 }

--- a/apps/api/src/modules/user/user.controller.ts
+++ b/apps/api/src/modules/user/user.controller.ts
@@ -51,7 +51,7 @@ export class UserController {
   async getUser(
     @Param('userId') targetUserId: string,
     @UserId() userId?: string,
-  ): Promise<GetUserDto> {
+  ): Promise<GetUserDto | undefined> {
     const user = await this.userService.getUserProfile(targetUserId, userId);
 
     return user;

--- a/apps/api/src/modules/user/user.repository.ts
+++ b/apps/api/src/modules/user/user.repository.ts
@@ -41,30 +41,6 @@ export class UserRepository {
     return this.repository.createQueryBuilder(alias);
   }
 
-  async findWithFollowInfo(targetUserId: string, currentUserId?: string) {
-    const qb = this.repository
-      .createQueryBuilder('user')
-      .where('user.id = :targetUserId', { targetUserId });
-
-    qb.loadRelationCountAndMap('user.followerCount', 'user.followers');
-    qb.loadRelationCountAndMap('user.followingCount', 'user.followings');
-
-    // 팔로우 중인지 확인 (로그인 한 경우만)
-    if (currentUserId) {
-      qb.loadRelationCountAndMap(
-        'user.isFollowing',
-        'user.followers',
-        'follow',
-        (qb) =>
-          qb.where('follow.followingUserId = :currentUserId', {
-            currentUserId,
-          }),
-      );
-    }
-
-    return qb.getOne();
-  }
-
   async searchByNickname(
     keyword: string,
     take: number,


### PR DESCRIPTION
## 🚀 PR 개요
follow service를 참조하여 해당 유저의 팔로우, 팔로워 데이터 숫자 반환

## 🔗 관련 이슈


## 🔍 작업 내용

- BE/ follow.service, repository
  - 특정 유저의 팔로우, 팔로워 숫자 반환
- BE/ user.controller, service

## ✔ 주요 고민과 해결 과정

## 📝 참고문서, 학습정리(선택)

## 기타
