### PR TITLE
[Fix] 사이드바 드로어 영역 닫기 동작 개선

### DIFF
--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -76,19 +76,23 @@ export default function Sidebar() {
   };
 
   const handleItemClick = (type: SidebarItemTypeValues) => {
+    // 열려 있는 드로어가 있다면 정리
     handleCloseDrawer();
 
+    // 드로어 아이콘 클릭 시 새 드로어 오픈
     if (isDrawerItem(type)) {
       setActiveItem(type);
       handleOpenDrawer(type);
       return;
     }
 
+    // 비로그인 상태에서 로그인이 필요한 기능 접근 시 로그인 모달 오픈
     if (needLogin(type) && !isAuthenticated) {
       openModal(MODAL_TYPES.LOGIN);
       return;
     }
 
+    // 프로필 아이콘 클릭 시 내 프로필 페이지 경로로 이동 / 그 외 페이지 경로 그대로 이동
     type === SidebarItemType.PROFILE ? handleMyProfileNavigate() : handleNavigate(type);
   };
 


### PR DESCRIPTION
## 🚀 PR 개요

- 사이드바 드로어를 외부 영역 클릭 시에도 닫힐 수 있도록 수정합니다.

## 🔗 관련 이슈

- Closes #187 

## 🔍 작업 내용
```ts
// Sidebar.tsx

// 사이드바 영역 클릭 여부 관리
const sidebarRef = useRef<HTMLDivElement>(null);

(...)

useEffect(() => {
  // 외부 영역 클릭 여부 판단 후 열린 드로어가 있다면 닫기
  const handleClickOutside = (event: MouseEvent) => {
    if (sidebarRef.current && !sidebarRef.current.contains(event.target as Node) && activeDrawer) {
      handleCloseDrawer();
    }
  };

 document.addEventListener('mousedown', handleClickOutside);
  return () => {
    // 언마운트 시 이벤트 리스너 정리
    document.removeEventListener('mousedown', handleClickOutside);
  };
}, [activeDrawer, handleCloseDrawer]);
```
- 사이드바 컴포넌트에 ref를 걸어서 관리
- document에 `mousedown` 이벤트 리스너 등록
- 클릭된 target이 사이드바 영역이 아니고 + 열려있는 드로어가 있으면 드로어 닫기 

## ✔ 주요 고민과 해결 과정

## 📝 참고문서, 학습정리(선택)

## 기타
