### PR TITLE
[fix] profileinfo에서 팔로우시 재렌더링 하도록 수정

### DIFF
--- a/apps/web/src/components/profile/ProfileInfo/ProfileInfo.tsx
+++ b/apps/web/src/components/profile/ProfileInfo/ProfileInfo.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import { Pencil, Check, X } from 'lucide-react';
-import Image from 'next/image';
 import ProfileActionButton from './ProfileActionButton';
 import FollowStats from './FollowStats';
 import { DEFAULT_IMAGES } from '@/constants/defaultImages';
@@ -13,7 +12,7 @@ import { updateProfile } from '@/api';
 
 export default function ProfileInfo({ profile, loggedInUserId }: { profile: Profile; loggedInUserId: string | null }) {
   const toggleFollow = useProfileStore((s) => s.toggleFollow);
-  const [displayProfile, setDisplayProfile] = useState(profile);
+  const updateProfileInfo = useProfileStore((s) => s.updateProfileInfo);
 
   const isOwner = loggedInUserId === profile.id;
   const [isEditing, setIsEditing] = useState(false);
@@ -22,21 +21,15 @@ export default function ProfileInfo({ profile, loggedInUserId }: { profile: Prof
     bio: profile.bio || '',
   });
 
-  useEffect(() => {
-    setEditForm({
-      nickname: displayProfile.nickname || '',
-      bio: displayProfile.bio || '',
-    });
-  }, [displayProfile]);
-
   const handleSave = async () => {
     await updateProfile({
       nickname: editForm.nickname,
       bio: editForm.bio,
     });
-    const optimisticData = { ...displayProfile, ...editForm };
-    setDisplayProfile(optimisticData);
-
+    updateProfileInfo({
+      nickname: editForm.nickname,
+      bio: editForm.bio,
+    });
     setIsEditing(false);
   };
 
@@ -44,7 +37,7 @@ export default function ProfileInfo({ profile, loggedInUserId }: { profile: Prof
     setIsEditing(false);
   };
 
-  const { nickname, profileImgUrl, bio, followerCount, followingCount, isFollowing } = displayProfile;
+  const { nickname, profileImgUrl, bio, followerCount, followingCount, isFollowing } = profile;
 
   return (
     <section className="max-w-4xl">

--- a/apps/web/src/stores/useProfileStore.ts
+++ b/apps/web/src/stores/useProfileStore.ts
@@ -7,11 +7,21 @@ interface ProfileState {
   toggleFollow: () => void;
   decrementFollowingCount: () => void;
   incrementFollowingCount: () => void;
+  updateProfileInfo: (updates: Partial<Profile>) => void;
 }
 
 export const useProfileStore = create<ProfileState>((set) => ({
   profile: null,
   setProfile: (profile) => set({ profile }),
+
+  /** 프로필 수정 */
+  updateProfileInfo: (updates) =>
+    set((state) => {
+      if (!state.profile) return {};
+      return {
+        profile: { ...state.profile, ...updates },
+      };
+    }),
 
   /** 현재 보고 있는 프로필 유저에 대한 팔로우/언팔로우 처리 */
   toggleFollow: () =>


### PR DESCRIPTION
## 🚀 PR 개요
프로필 페이지에서 보여주는 상태를 변경하여 다시 랜더링이 정상적으로 이뤄지도록 수정했습니다. 

## 🔗 관련 이슈

## 🔍 작업 내용

ProfileInfo에서 수정, 팔로우가 이뤄지는 경우 API를 요청하고 -> useProfileStore의 상태를 갱신합니다.

상태가 변경되면 profileInfo를 호출하는 컴포넌트 ProfileView에서 props(profile)를 갱신된 상태로 전달하여 재렌더링합니다.

## ✔ 주요 고민과 해결 과정

## 📝 참고문서, 학습정리(선택)

## 기타
