### PR TITLE
[Refactor] nowplaying 렌더링 구조 분리로 반복 렌더 최소화

### DIFF
--- a/apps/web/src/components/player/NowPlaying.tsx
+++ b/apps/web/src/components/player/NowPlaying.tsx
@@ -2,245 +2,107 @@
 
 import type { MusicResponseDto as Music } from '@repo/dto';
 import { MusicProvider } from '@repo/dto/values';
-import { Pause, Play, Shuffle, SkipBack, SkipForward, PlusCircle, FolderPlus } from 'lucide-react';
-import { useMemo } from 'react';
-import { usePlayerStore } from '@/stores';
-import { VolumeControl, SeekBar } from './index';
+import { useCallback } from 'react';
 import { useMusicActions } from '@/hooks';
-import { useModalStore, MODAL_TYPES } from '@/stores';
 import { useAuthMe } from '@/hooks/auth/client/useAuthMe';
-import { formatMs, enqueueLog } from '@/utils';
-import { DEFAULT_IMAGES } from '@/constants';
+import { useModalStore, MODAL_TYPES, usePlayerStore } from '@/stores';
+import { enqueueLog } from '@/utils';
 import { makeArchiveAddMusicLog, makePostAddMusicLog } from '@/api';
 
-interface NowPlayingProps {
+import { NowPlayingCoverPlayback, NowPlayingProgressTick, NowPlayingMetaActions, NowPlayingControlsStatic, PlaybackProvider } from './index';
+
+type Props = {
   currentMusic: Music | null;
   isPlaying: boolean;
-
   canPrev: boolean;
   canNext: boolean;
-
-  positionMs: number;
-  durationMs: number;
-
   onTogglePlay: () => void;
   onPrev: () => void;
   onNext: () => void;
+};
 
-  onShuffle: () => void;
-  onSeek: (ms: number) => void;
-
-  youtubeContainerRef: React.RefObject<HTMLDivElement | null> | null;
-}
-
-export default function NowPlaying({
-  currentMusic,
-  isPlaying,
-  canPrev,
-  canNext,
-  positionMs,
-  durationMs,
-  onTogglePlay,
-  onPrev,
-  onNext,
-  onShuffle,
-  onSeek,
-  youtubeContainerRef,
-}: NowPlayingProps) {
-  const isPlayable = Boolean(currentMusic);
-  const isYouTube = currentMusic?.provider === MusicProvider.YOUTUBE;
-
+export default function NowPlaying({ currentMusic, isPlaying, canPrev, canNext, onTogglePlay, onPrev, onNext }: Props) {
   const volume = usePlayerStore((s) => s.volume);
   const setVolume = usePlayerStore((s) => s.setVolume);
   const playError = usePlayerStore((s) => s.playError);
   const setPlayError = usePlayerStore((s) => s.setPlayError);
 
-  /**
-   * NOTE:
-   * - 사용자의 로그인 유무를 체크한다.
-   * - 사용자가 보관함 추가와 컨텐츠 생성 버튼을 누를 때 로그인 유무로 지원한다.
-   * - 보관함을 누르면 로그인한 사용자 Id로 보관함 리스트 모달을 불러온다.
-   */
-  const { userId, isAuthenticated } = useAuthMe();
+  const { isAuthenticated } = useAuthMe();
   const { openModal } = useModalStore();
-
-  /** 보관함 추가와 컨텐츠 생성을 위한 함수  */
   const { openWriteModalWithMusic, addMusicToArchive } = useMusicActions();
 
-  const shownDurationMs = useMemo(() => {
-    if (!currentMusic) return 0;
-    return durationMs > 0 ? durationMs : currentMusic.durationMs;
-  }, [currentMusic, durationMs]);
+  const isPlayable = Boolean(currentMusic);
+  const isYouTube = currentMusic?.provider === MusicProvider.YOUTUBE;
 
-  const currentText = useMemo(() => formatMs(positionMs), [positionMs]);
-  const durationText = useMemo(() => formatMs(shownDurationMs), [shownDurationMs]);
+  const clearPlayError = useCallback(() => setPlayError(null), [setPlayError]);
 
-  const handleTogglePlayClick = () => {
+  const safeTogglePlay = useCallback(() => {
     if (!isPlayable) return;
-    setPlayError(null);
+    clearPlayError();
     onTogglePlay();
-  };
+  }, [isPlayable, clearPlayError, onTogglePlay]);
 
-  const handlePrevClick = () => {
+  const safePrev = useCallback(() => {
     if (!canPrev) return;
-    setPlayError(null);
+    clearPlayError();
     onPrev();
-  };
+  }, [canPrev, clearPlayError, onPrev]);
 
-  const handleNextClick = () => {
+  const safeNext = useCallback(() => {
     if (!canNext) return;
-    setPlayError(null);
+    clearPlayError();
     onNext();
-  };
+  }, [canNext, clearPlayError, onNext]);
 
-  const handleShuffleClick = () => {
-    onShuffle();
-  };
-
-  const handlePostClick = async () => {
+  const handlePost = useCallback(async () => {
     if (!isAuthenticated) {
       openModal(MODAL_TYPES.LOGIN);
       return;
     }
-
     if (!currentMusic) return;
 
-    // 로그(포스트로 추가한 music id)
     enqueueLog(makePostAddMusicLog({ musicIds: [currentMusic.id] }));
-
-    // DB upsert 포함(내부 ensureMusicInDb)
     await openWriteModalWithMusic(currentMusic);
-  };
+  }, [isAuthenticated, openModal, currentMusic, openWriteModalWithMusic]);
 
-  const handleSaveClick = async () => {
+  const handleSave = useCallback(async () => {
     if (!isAuthenticated) {
       openModal(MODAL_TYPES.LOGIN);
       return;
     }
-
     if (!currentMusic) return;
 
-    // 로그(보관함에 추가한 music id)
     enqueueLog(makeArchiveAddMusicLog({ musicIds: [currentMusic.id] }));
-
-    // DB upsert 포함(내부 ensureMusicInDb)
     await addMusicToArchive(currentMusic);
-  };
+  }, [isAuthenticated, openModal, currentMusic, addMusicToArchive]);
+
+  const handleShuffle = useCallback(() => {
+    // TODO
+  }, []);
 
   return (
     <div className="p-4 border-b-2 border-primary">
       <h2 className="text-xs font-bold text-accent-pink tracking-widest uppercase mb-2 text-center">Now Playing</h2>
 
-      {/* 기존 앨범커버 영역 */}
-      <div className="mx-auto w-full max-w-55 aspect-square rounded-2xl border-2 border-primary overflow-hidden bg-gray-4 mb-2 flex items-center justify-center">
-        {/* youtube 음악이 재생될 때 */}
-        <div className={`w-full h-full ${isYouTube ? '' : 'hidden'}`}>
-          <div ref={youtubeContainerRef ?? undefined} className="w-full h-full" />
-        </div>
+      <PlaybackProvider>
+        <NowPlayingCoverPlayback currentMusic={currentMusic} isYouTube={isYouTube} />
+        <NowPlayingMetaActions currentMusic={currentMusic} playError={playError} onPost={handlePost} onSave={handleSave} />
+        <NowPlayingProgressTick currentMusic={currentMusic} />
+      </PlaybackProvider>
 
-        {/* itunes 음악이 재생될 때 */}
-        <img
-          src={currentMusic?.albumCoverUrl || DEFAULT_IMAGES.ALBUM}
-          alt={currentMusic?.title ?? '현재 재생 음악 없음'}
-          className={`w-full h-full object-cover ${!currentMusic || isYouTube ? 'hidden' : ''}`}
-        />
-
-        {/* 재생중인 음악이 없을 때 */}
-        {!currentMusic && <span className="text-sm font-bold text-gray-2">No Music</span>}
-      </div>
-
-      <div className="text-center mb-2">
-        {currentMusic ? (
-          <>
-            <h3 className="text-lg font-black text-primary truncate">{currentMusic.title}</h3>
-            <p className="text-xs font-bold text-gray-1 truncate">{currentMusic.artistName}</p>
-          </>
-        ) : (
-          <>
-            <p className="font-bold text-gray-1">재생 중인 음악이 없습니다.</p>
-            <p className="text-sm text-gray-2 mt-1">피드/검색에서 음악을 선택해보세요.</p>
-          </>
-        )}
-      </div>
-
-      {/* 재생 실패 메시지(토스트 대신 인라인) */}
-      {currentMusic && playError ? (
-        <div className="mb-3 rounded-xl border-2 border-secondary bg-secondary/10 px-3 py-2 text-sm font-bold text-secondary">{playError}</div>
-      ) : null}
-
-      {currentMusic && (
-        <div className="flex items-center justify-center gap-2 mb-3">
-          <button
-            type="button"
-            onClick={handlePostClick}
-            title={'컨텐츠 작성'}
-            className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-primary text-white font-bold text-xs opacity-50 cursor-not-allowed"
-          >
-            <PlusCircle className="w-4 h-4" />
-            게시
-          </button>
-
-          <button
-            type="button"
-            onClick={handleSaveClick}
-            title={'보관함에 음악 추가'}
-            className="flex items-center gap-1 px-3 py-1.5 rounded-full border-2 border-primary text-primary font-bold text-xs opacity-50 cursor-not-allowed"
-          >
-            <FolderPlus className="w-4 h-4" />
-            저장
-          </button>
-        </div>
-      )}
-
-      <div className={`mb-3${currentMusic ? '' : ' opacity-50'}`}>
-        {/* 진행바 + seek */}
-        <SeekBar positionMs={positionMs} durationMs={shownDurationMs} disabled={!currentMusic || shownDurationMs <= 0} onSeek={onSeek} />
-        <div className="flex justify-between text-[11px] font-bold text-gray-2 mt-2">
-          <span>{currentMusic ? currentText : '0:00'}</span>
-          <span>{currentMusic ? durationText : '0:00'}</span>
-        </div>
-      </div>
-
-      <div className={`flex items-center justify-center gap-4${currentMusic ? '' : ' opacity-50'}`}>
-        <button type="button" onClick={handleShuffleClick} disabled title={'랜덤 재생 버튼'} className="text-gray-2 opacity-50 cursor-not-allowed">
-          <Shuffle className="w-5 h-5" />
-        </button>
-
-        <button
-          type="button"
-          onClick={handlePrevClick}
-          disabled={!!currentMusic && !canPrev}
-          title={canPrev ? '이전 곡' : '이전 곡 없음'}
-          className={currentMusic ? 'text-primary disabled:opacity-50 disabled:cursor-not-allowed' : 'text-gray-2 cursor-not-allowed'}
-        >
-          <SkipBack className="w-6 h-6" />
-        </button>
-
-        <button
-          type="button"
-          onClick={handleTogglePlayClick}
-          disabled={!currentMusic}
-          className={
-            currentMusic
-              ? 'w-12 h-12 rounded-full bg-primary text-white flex items-center justify-center shadow-[3px_3px_0px_0px_#00ebc7]'
-              : 'w-12 h-12 rounded-full bg-gray-2 text-white flex items-center justify-center cursor-not-allowed'
-          }
-          title={isPlaying ? '일시정지' : '재생'}
-        >
-          {currentMusic && isPlaying ? <Pause className="w-6 h-6" /> : <Play className="w-6 h-6 ml-0.5" />}
-        </button>
-
-        <button
-          type="button"
-          onClick={handleNextClick}
-          disabled={!!currentMusic && !canNext}
-          title={canNext ? '다음 곡' : '다음 곡 없음'}
-          className={currentMusic ? 'text-primary disabled:opacity-50 disabled:cursor-not-allowed' : 'text-gray-2 cursor-not-allowed'}
-        >
-          <SkipForward className="w-6 h-6" />
-        </button>
-        <VolumeControl value={volume} onChange={setVolume} disabled={!currentMusic} />
-      </div>
+      <NowPlayingControlsStatic
+        enabled={Boolean(currentMusic)}
+        isPlaying={isPlaying}
+        canPrev={canPrev}
+        canNext={canNext}
+        onClearPlayError={clearPlayError}
+        onTogglePlay={safeTogglePlay}
+        onPrev={safePrev}
+        onNext={safeNext}
+        onShuffle={handleShuffle}
+        volume={volume}
+        onVolumeChange={setVolume}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/player/index.ts
+++ b/apps/web/src/components/player/index.ts
@@ -1,6 +1,7 @@
 export { default as RightPanel } from './RightPanel';
-export { default as NowPlaying } from './NowPlaying';
 export { default as QueueList } from './QueueList';
 export { default as MiniPlayerBar } from './MiniPlayerBar';
 export { default as VolumeControl } from './VolumeControl';
 export { default as SeekBar } from './SeekBar';
+export { default as NowPlaying } from './NowPlaying';
+export * from './nowPlaying/index';

--- a/apps/web/src/components/player/nowPlaying/NowPlayingControlsStatic.tsx
+++ b/apps/web/src/components/player/nowPlaying/NowPlayingControlsStatic.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import React, { memo } from 'react';
+import { Pause, Play, Shuffle, SkipBack, SkipForward } from 'lucide-react';
+import VolumeControl from '../VolumeControl';
+
+type Props = {
+  enabled: boolean;
+
+  isPlaying: boolean;
+  canPrev: boolean;
+  canNext: boolean;
+
+  onClearPlayError: () => void;
+  onTogglePlay: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+  onShuffle: () => void;
+
+  volume: number;
+  onVolumeChange: (v: number) => void;
+};
+
+function NowPlayingControlsStaticBase({
+  enabled,
+  isPlaying,
+  canPrev,
+  canNext,
+  onClearPlayError,
+  onTogglePlay,
+  onPrev,
+  onNext,
+  onShuffle,
+  volume,
+  onVolumeChange,
+}: Props) {
+  return (
+    <div className={`flex items-center justify-center gap-4${enabled ? '' : ' opacity-50'}`}>
+      <button type="button" onClick={onShuffle} disabled title="랜덤 재생 버튼" className="text-gray-2 opacity-50 cursor-not-allowed">
+        <Shuffle className="w-5 h-5" />
+      </button>
+
+      <button
+        type="button"
+        onClick={() => {
+          if (!enabled || !canPrev) return;
+          onClearPlayError();
+          onPrev();
+        }}
+        disabled={enabled && !canPrev}
+        title={canPrev ? '이전 곡' : '이전 곡 없음'}
+        className={enabled ? 'text-primary disabled:opacity-50 disabled:cursor-not-allowed' : 'text-gray-2 cursor-not-allowed'}
+      >
+        <SkipBack className="w-6 h-6" />
+      </button>
+
+      <button
+        type="button"
+        onClick={() => {
+          if (!enabled) return;
+          onClearPlayError();
+          onTogglePlay();
+        }}
+        disabled={!enabled}
+        className={
+          enabled
+            ? 'w-12 h-12 rounded-full bg-primary text-white flex items-center justify-center shadow-[3px_3px_0px_0px_#00ebc7]'
+            : 'w-12 h-12 rounded-full bg-gray-2 text-white flex items-center justify-center cursor-not-allowed'
+        }
+        title={isPlaying ? '일시정지' : '재생'}
+      >
+        {enabled && isPlaying ? <Pause className="w-6 h-6" /> : <Play className="w-6 h-6 ml-0.5" />}
+      </button>
+
+      <button
+        type="button"
+        onClick={() => {
+          if (!enabled || !canNext) return;
+          onClearPlayError();
+          onNext();
+        }}
+        disabled={enabled && !canNext}
+        title={canNext ? '다음 곡' : '다음 곡 없음'}
+        className={enabled ? 'text-primary disabled:opacity-50 disabled:cursor-not-allowed' : 'text-gray-2 cursor-not-allowed'}
+      >
+        <SkipForward className="w-6 h-6" />
+      </button>
+
+      <VolumeControl value={volume} onChange={onVolumeChange} disabled={!enabled} />
+    </div>
+  );
+}
+
+export default memo(NowPlayingControlsStaticBase);

--- a/apps/web/src/components/player/nowPlaying/NowPlayingCoverPlayback.tsx
+++ b/apps/web/src/components/player/nowPlaying/NowPlayingCoverPlayback.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { MusicResponseDto as Music } from '@repo/dto';
+import React, { memo } from 'react';
+import { DEFAULT_IMAGES } from '@/constants';
+import { usePlaybackRefs } from './PlaybackProvider';
+
+type Props = {
+  currentMusic: Music | null;
+  isYouTube: boolean;
+};
+
+function NowPlayingCoverPlaybackBase({ currentMusic, isYouTube }: Props) {
+  const { containerRef } = usePlaybackRefs();
+
+  return (
+    <div className="mx-auto w-full max-w-55 aspect-square rounded-2xl border-2 border-primary overflow-hidden bg-gray-4 mb-2 flex items-center justify-center">
+      <div className={`w-full h-full ${isYouTube ? '' : 'hidden'}`}>
+        <div ref={isYouTube ? (containerRef ?? undefined) : undefined} className="w-full h-full" />
+      </div>
+
+      <img
+        src={currentMusic?.albumCoverUrl || DEFAULT_IMAGES.ALBUM}
+        alt={currentMusic?.title ?? '현재 재생 음악 없음'}
+        className={`w-full h-full object-cover ${!currentMusic || isYouTube ? 'hidden' : ''}`}
+      />
+
+      {!currentMusic && <span className="text-sm font-bold text-gray-2">No Music</span>}
+    </div>
+  );
+}
+
+export default memo(NowPlayingCoverPlaybackBase);

--- a/apps/web/src/components/player/nowPlaying/NowPlayingMetaActions.tsx
+++ b/apps/web/src/components/player/nowPlaying/NowPlayingMetaActions.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import type { MusicResponseDto as Music } from '@repo/dto';
+import React, { memo } from 'react';
+import { PlusCircle, FolderPlus } from 'lucide-react';
+
+type Props = {
+  currentMusic: Music | null;
+  playError: string | null;
+
+  onPost: () => void;
+  onSave: () => void;
+};
+
+function NowPlayingMetaActionsBase({ currentMusic, playError, onPost, onSave }: Props) {
+  const enabled = Boolean(currentMusic);
+
+  return (
+    <>
+      <div className="text-center mb-2">
+        {currentMusic ? (
+          <>
+            <h3 className="text-lg font-black text-primary truncate">{currentMusic.title}</h3>
+            <p className="text-xs font-bold text-gray-1 truncate">{currentMusic.artistName}</p>
+          </>
+        ) : (
+          <>
+            <p className="font-bold text-gray-1">재생 중인 음악이 없습니다.</p>
+            <p className="text-sm text-gray-2 mt-1">피드/검색에서 음악을 선택해보세요.</p>
+          </>
+        )}
+      </div>
+
+      {enabled && playError ? (
+        <div className="mb-3 rounded-xl border-2 border-secondary bg-secondary/10 px-3 py-2 text-sm font-bold text-secondary">{playError}</div>
+      ) : null}
+
+      {enabled && (
+        <div className="flex items-center justify-center gap-2 mb-3">
+          <button
+            type="button"
+            onClick={onPost}
+            title="컨텐츠 작성"
+            className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-primary text-white font-bold text-xs opacity-50 cursor-not-allowed"
+          >
+            <PlusCircle className="w-4 h-4" />
+            게시
+          </button>
+
+          <button
+            type="button"
+            onClick={onSave}
+            title="보관함에 음악 추가"
+            className="flex items-center gap-1 px-3 py-1.5 rounded-full border-2 border-primary text-primary font-bold text-xs opacity-50 cursor-not-allowed"
+          >
+            <FolderPlus className="w-4 h-4" />
+            저장
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default memo(NowPlayingMetaActionsBase);

--- a/apps/web/src/components/player/nowPlaying/NowPlayingProgressTick.tsx
+++ b/apps/web/src/components/player/nowPlaying/NowPlayingProgressTick.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { MusicResponseDto as Music } from '@repo/dto';
+import React, { memo, useMemo } from 'react';
+import SeekBar from '../SeekBar';
+import { formatMs } from '@/utils';
+import { usePlaybackProgress, usePlaybackRefs } from './PlaybackProvider';
+
+type Props = {
+  currentMusic: Music | null;
+};
+
+function NowPlayingProgressTickBase({ currentMusic }: Props) {
+  const { positionMs, durationMs: rawDurationMs } = usePlaybackProgress();
+  const { seekToMs } = usePlaybackRefs();
+
+  const enabled = Boolean(currentMusic);
+
+  const durationMs = useMemo(() => {
+    if (!currentMusic) return 0;
+    return rawDurationMs > 0 ? rawDurationMs : currentMusic.durationMs;
+  }, [currentMusic, rawDurationMs]);
+
+  const currentText = useMemo(() => formatMs(positionMs), [positionMs]);
+  const durationText = useMemo(() => formatMs(durationMs), [durationMs]);
+
+  return (
+    <div className={`mb-3${enabled ? '' : ' opacity-50'}`}>
+      <SeekBar positionMs={positionMs} durationMs={durationMs} disabled={!enabled || durationMs <= 0} onSeek={seekToMs} />
+      <div className="flex justify-between text-[11px] font-bold text-gray-2 mt-2">
+        <span>{enabled ? currentText : '0:00'}</span>
+        <span>{enabled ? durationText : '0:00'}</span>
+      </div>
+    </div>
+  );
+}
+
+export default memo(NowPlayingProgressTickBase);

--- a/apps/web/src/components/player/nowPlaying/PlaybackProvider.tsx
+++ b/apps/web/src/components/player/nowPlaying/PlaybackProvider.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React, { createContext, useContext, useMemo } from 'react';
+import { usePlayback } from '@/hooks';
+
+type PlaybackKind = 'youtube' | 'itunes';
+
+type PlaybackRefsValue = {
+  kind: PlaybackKind;
+  containerRef: React.RefObject<HTMLDivElement | null> | null;
+  seekToMs: (ms: number) => void;
+};
+
+type PlaybackProgressValue = {
+  positionMs: number;
+  durationMs: number;
+};
+
+const PlaybackRefsContext = createContext<PlaybackRefsValue | null>(null);
+const PlaybackProgressContext = createContext<PlaybackProgressValue | null>(null);
+
+export function PlaybackProvider({ children }: { children: React.ReactNode }) {
+  const playback = usePlayback();
+
+  // 거의 안 변하는 값들만(cover는 이것만 구독)
+  const refsValue = useMemo<PlaybackRefsValue>(
+    () => ({
+      kind: playback.kind as PlaybackKind,
+      containerRef: playback.kind === 'youtube' ? playback.containerRef : null,
+      seekToMs: playback.seekToMs,
+    }),
+    [playback.kind, playback.seekToMs, playback.kind === 'youtube' ? playback.containerRef : null],
+  );
+
+  // tick으로 자주 변하는 값들만(progress는 이것만 구독)
+  const progressValue = useMemo<PlaybackProgressValue>(
+    () => ({
+      positionMs: playback.positionMs,
+      durationMs: playback.durationMs,
+    }),
+    [playback.positionMs, playback.durationMs],
+  );
+
+  return (
+    <PlaybackRefsContext.Provider value={refsValue}>
+      <PlaybackProgressContext.Provider value={progressValue}>{children}</PlaybackProgressContext.Provider>
+    </PlaybackRefsContext.Provider>
+  );
+}
+
+export function usePlaybackRefs() {
+  const v = useContext(PlaybackRefsContext);
+  if (!v) throw new Error('usePlaybackRefs must be used within PlaybackProvider');
+  return v;
+}
+
+export function usePlaybackProgress() {
+  const v = useContext(PlaybackProgressContext);
+  if (!v) throw new Error('usePlaybackProgress must be used within PlaybackProvider');
+  return v;
+}

--- a/apps/web/src/components/player/nowPlaying/index.ts
+++ b/apps/web/src/components/player/nowPlaying/index.ts
@@ -1,0 +1,5 @@
+export { default as NowPlayingCoverPlayback } from './NowPlayingCoverPlayback';
+export { default as NowPlayingProgressTick } from './NowPlayingProgressTick';
+export { default as NowPlayingMetaActions } from './NowPlayingMetaActions';
+export { default as NowPlayingControlsStatic } from './NowPlayingControlsStatic';
+export * from './PlaybackProvider';


### PR DESCRIPTION
## 🚀 PR 개요
NowPlaying 렌더링 구조를 분리하고 `usePlayback` 구독 위치를 조정하여 **progress tick으로 인한 반복 렌더를 최소화**했습니다.
또한 `usePlayback()`의 **중복 호출로 발생하던 YouTube progress 0초 고정** 문제를 `PlaybackProvider(Context)` 기반 단일 인스턴스 공유 구조로 해결했습니다.

---

## 🔗 관련 이슈
- Closes #228

---

## 🔍 작업 내용
- `RightPanel`에서 `usePlayback` 구독 제거 → **NowPlaying(컨테이너/Provider)로 책임 이동**
- NowPlaying을 `nowPlaying/` 하위로 분리하여 **UI/상태/렌더 영역을 역할 단위로 모듈화**
- `usePlayback()` 중복 호출 제거를 위해 **PlaybackProvider(Context)로 단일 인스턴스 공유**
- progress tick 렌더 범위를 제한하기 위해 **Progress(빈번) vs Refs/Controls(안 변함) 분리**
- export 및 파일 구조 정리

**변경 파일**

- `apps/web/src/components/player/NowPlaying.tsx`
    - 컨테이너 역할로 정리, Provider 적용 및 외부 렌더 영향 최소화
- `apps/web/src/components/player/RightPanel.tsx`
    - progress 구독 제거, RightPanel/QueueList 리렌더 차단
- `apps/web/src/components/player/index.ts`
    - export 정리
- `apps/web/src/components/player/nowPlaying/*`
    - 세부 컴포넌트 + Provider 신규 추가(모듈화)

https://github.com/user-attachments/assets/a4cc6e6e-3542-49bf-83f8-3534bf2fb8c0




---

## ✔ 주요 고민과 해결 과정

### 1) 반복 렌더링 원인 제거: RightPanel → NowPlaying으로 tick 구독 위치 이동
- **문제**
    - `RightPanel`에서 `usePlayback()`을 구독하고 있어, `progress tick(setInterval)`마다
        
        RightPanel 전체가 리렌더 → 하위 `QueueList`까지 연쇄 렌더
        
- **해결**
    - progress 관련 구독을 `NowPlaying(컨테이너/Provider)`로 이동하고,
        
        `RightPanel`은 플레이어 영역을 “표시”만 하도록 단순화
        
- **결과**
    - tick 렌더 범위를 NowPlaying 영역으로 국소화하여 사이드/큐 렌더 영향 최소화

### 2) 책임 분리 및 파일 구조 정리: nowPlaying 폴더 도입
- **문제**
    - NowPlaying 단일 파일에 UI/상태/부가 로직이 섞여 변경 시 영향 범위가 커짐
- **해결**
    - `nowPlaying/` 하위로 역할 단위 분리
        - Cover(YouTube containerRef/앨범 커버)
        - Meta+Actions(제목/아티스트/게시/저장)
        - ProgressTick(SeekBar + time label)
        - ControlsStatic(컨트롤 + 볼륨)
        - PlaybackProvider(단일 playback 인스턴스 공유)
- **결과**
    - 가독성/유지보수성 개선, 변경 범위 최소화, 기능 추가 시 확장 용이

### 3) YouTube progress 0초 고정 버그 해결: usePlayback 중복 호출 제거
- **문제**
    - Cover/Progress 등 여러 컴포넌트에서 `usePlayback()`을 각각 호출하면서
        
        “재생 player 인스턴스”와 “progress를 읽는 인스턴스”가 달라져
        
        `positionMs/durationMs`가 0으로 고정되는 상황 발생
        
- **해결**
    - `PlaybackProvider`에서 `usePlayback()`을 1회만 호출하고 Context로 공유
- **결과**
    - YouTube 재생과 progress 표시가 동일 인스턴스를 바라보며 동기화 정상화

### 4) 성능 최적화: Context를 2개로 분리
- **문제**
    - Context 하나에 progress까지 포함하면 tick마다 Cover/Static까지 리렌더될 수 있음
- **해결**
    - `PlaybackRefsContext` (containerRef, seekToMs 등 변화 적음)
    - `PlaybackProgressContext` (positionMs/durationMs, tick 잦음)
- **결과**
    - tick 업데이트는 주로 ProgressTick만 갱신, 나머지 영역 렌더 안정화

---

## 📝 참고문서, 학습정리(선택)
- React Context 리렌더 범위 최적화(값 분리/메모이제이션) 관련 내부 정리 예정

---

## 기타
- 추후 확장(YouTube 외 provider/플레이어 추가) 시 Provider/Context 구조를 그대로 재사용 가능
- tick 주기/렌더 비용이 더 커질 경우, ProgressTick 내부에서 추가적인 memo/selector 적용 여지 있음

---
