### PR TITLE
fix: 큐에 추가되는 음악 중 이미 큐에 있는 건 큐에서 삭제하고 다시 마지막에 모두 추가하는 것으로 수정

### DIFF
--- a/apps/web/src/stores/usePlayerStore.ts
+++ b/apps/web/src/stores/usePlayerStore.ts
@@ -184,9 +184,10 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
     const items = normalizeToArray(music);
 
     set((state) => {
-      const deduped = items.filter((item) => !hasMusic(state.queue, item.id));
-      if (deduped.length === 0) return state;
-      return { queue: [...state.queue, ...deduped] };
+      const before = state.queue;
+      const addIdSet = new Set(items.map((m) => m.id));
+      const filtered = before.filter((m) => !addIdSet.has(m.id));
+      return { queue: [...filtered, ...items] };
     });
   },
   /**


### PR DESCRIPTION
## 🚀 PR 개요

큐에 추가되는 음악 중 이미 큐에 있는 건 큐에서 삭제하고 다시 마지막에 모두 추가하는 것으로 수정

## 🔗 관련 이슈

Closes #242 

## 🔍 작업 내용

이전 코드

추가되는 음악 중에서 기존 큐에 없던 음악만 추가했던 기존 코드

```ts
  addToQueue: (music) => {
    const items = normalizeToArray(music);

    set((state) => {
      const deduped = items.filter((item) => !hasMusic(state.queue, item.id));
      if (deduped.length === 0) return state;
      return { queue: [...state.queue, ...deduped] };
    });
  },
```

수정 버전

```ts
  addToQueue: (music) => {
    const items = normalizeToArray(music);

    set((state) => {
      const before = state.queue;
      const addIdSet = new Set(items.map((m) => m.id));
      const filtered = before.filter((m) => !addIdSet.has(m.id));
      return { queue: [...filtered, ...items] };
    });
  },
```

기존 큐에서 추가되는 음악은 삭제하고 다시 마지막에 추가하는 것으로 수정

## ✔ 주요 고민과 해결 과정

## 📝 참고문서, 학습정리(선택)

## 기타

Enter Sandman 음악이 기존에 있었을 때 삭제되고 추가한 플리 음악 순서대로 마지막에 추가된 모습

<img width="1353" height="1111" alt="image" src="https://github.com/user-attachments/assets/8b5b3dc3-8eea-4d40-ab3b-3e475b5f6b27" />
<img width="1059" height="885" alt="image" src="https://github.com/user-attachments/assets/70b0ec1b-4161-4b73-9767-c82991e4096f" />
<img width="616" height="829" alt="image" src="https://github.com/user-attachments/assets/4c3cee45-4413-4f88-bf45-8c0c713f54f4" />

