### PR TITLE
[Refactor] 재생 큐 정렬 규칙 안정화 

### DIFF
--- a/apps/web/src/components/player/RightPanel.tsx
+++ b/apps/web/src/components/player/RightPanel.tsx
@@ -26,7 +26,7 @@ export default function RightPanel() {
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const queue = usePlayerStore((s) => s.queue);
 
-  const playMusic = usePlayerStore((s) => s.playMusic);
+  const selectMusic = usePlayerStore((s) => s.selectMusic);
   const togglePlay = usePlayerStore((s) => s.togglePlay);
   const clearQueue = usePlayerStore((s) => s.clearQueue);
   const removeFromQueue = usePlayerStore((s) => s.removeFromQueue);
@@ -83,7 +83,7 @@ export default function RightPanel() {
           onRemove={removeFromQueue}
           onMoveUp={moveUp}
           onMoveDown={moveDown}
-          onSelect={playMusic}
+          onSelect={selectMusic}
         />
       </section>
     </>


### PR DESCRIPTION
## 🚀 PR 개요
- 재생 큐에 음악이 추가되는 로직이 모달마다 달라서 생기는 문제 해결 
- 재생 큐(현재 재생목록)에서 **“외부에서 재생(play)”** 과 **“큐 내부에서 곡 선택(select)”** 의 의미가 달라서 생기던 UX 문제를 해결
- 수정한 `playMusic()`가 “재생한 곡을 큐 맨 뒤로 이동(moveToEnd)”하도록 변경되면서,
    **QueueList에서 곡을 클릭해도 동일 로직이 적용**되어 곡이 클릭 즉시 아래로 내려가는 문제가 발생
- 이를 해결하기 위해 **재생 트리거를 2종으로 분리**
    - `playMusic`: 외부 컨텍스트(피드/검색 등)에서 재생 → 큐를 “최근 재생 순”으로 유지
    - `selectMusic`: 큐 내부에서 곡 선택 → 큐 순서 유지(필요 시만 append)

---
## 🔗 관련 이슈
- Closes #249

---

## 🔍 작업 내용
### 1) `usePlayerStore`에 `selectMusic` 액션 추가
- `playMusic`는 “최근 재생한 곡을 큐 뒤로” 정책 유지
- `selectMusic`는 “큐에서 선택” 정책(순서 유지) 제공

**핵심 변경 코드 (발췌)**
```tsx
// 재생: 큐에 있으면 제거 후 맨 뒤로 이동(최근 재생 순 유지)
playMusic: (music) => {
  const { currentMusic, queue } = get();
  set({ playError: null });

  if (isSameMusic(currentMusic, music)) {
    get().togglePlay();
    return;
  }

  set({
    currentMusic: music,
    isPlaying: true,
    queue: moveToEnd(queue, music),
  });
},
```

```tsx
// 큐 선택: 큐 순서는 유지(없을 때만 append)
selectMusic: (music) => {
  const { currentMusic, queue } = get();
  set({ playError: null });

  if (isSameMusic(currentMusic, music)) {
    get().togglePlay();
    return;
  }

  set({
    currentMusic: music,
    isPlaying: true,
    queue: appendIfMissing(queue, music),
  });
},
```

그리고 큐 이동 규칙을 명확히 하는 헬퍼도 추가했습니다.
```tsx
const moveToEnd = (queue: Music[], music: Music): Music[] => {
  const filtered = removeById(queue, music.id);
  return [...filtered, music];
};
```

---

### 2) QueueList 클릭 재생을 `selectMusic`로 연결
- `RightPanel`에서 `QueueList`의 `onSelect`를 `selectMusic`로 연결하여,
    **큐 안에서 곡 선택 시 곡이 아래로 이동하지 않도록** 변경했습니다.
    
**핵심 변경 코드 (발췌)**
```tsx
const selectMusic = usePlayerStore((s) => s.selectMusic);

<QueueList
  queue={queue}
  currentMusicId={currentMusic?.id ?? null}
  onClear={clearQueue}
  onRemove={removeFromQueue}
  onMoveUp={moveUp}
  onMoveDown={moveDown}
  onSelect={selectMusic}
/>
```

---

## ✔ 주요 고민과 해결 과정
### 고민 1) “playMusic” 정책을 바꾸면 큐 내부 UX가 깨진다
- `playMusic`가 “재생할 때마다 큐 뒤로 이동” 정책을 갖게 되면,
    큐에서 곡을 클릭하는 행위도 “재생”이기 때문에 같은 정책이 적용되어
    **사용자가 선택한 곡이 클릭 즉시 맨 아래로 내려가는 UX 문제가 발생**했습니다.
    

✅ 해결: “재생”의 맥락을 두 가지로 나눠 역할을 분리
- **외부(피드/검색/게시글 등)에서 재생**: 최근 재생 곡을 큐 뒤로 보내는 게 자연스러움
    → `playMusic` 유지
    
- **큐 내부에서 선택**: 순서는 사용자 편집 결과이므로 유지되어야 자연스러움
    → `selectMusic` 도입
    

---

### 고민 2) 기존 호출부 영향 최소화
- 기존에 `playMusic`를 호출하던 위치는 그대로 유지하면서
- “큐 내부 선택”에만 `selectMusic`를 적용하도록 `RightPanel`에서 wiring을 변경했습니다.

✅ 결과: 기존 기능 영향 최소화 + 큐 선택 UX만 정확히 개선

---

## 📝 참고문서, 학습정리
- 재생 큐 UX 패턴 정리:
    - “외부에서 곡을 재생”은 최근 재생 곡이 큐 뒤로 가는 것이 자연스럽고
    - “큐 내부에서 곡 선택”은 순서 변경이 아닌 current 변경이므로 큐 순서를 유지하는 것이 자연스럽다

---

## 기타

### ✅ 동작 검증 체크리스트
- [x]  피드/검색에서 곡 재생 시: 동일 곡이 큐에 있으면 제거 후 맨 뒤로 이동(최근 재생 순 유지)
- [x]  QueueList에서 곡 클릭 시: 해당 곡이 재생되지만 큐 순서가 바뀌지 않음
- [x]  동일 곡 재클릭 시: play/pause 토글 정상 동작
- [x]  prev/next 및 queue reorder 기능 영향 없음

https://github.com/user-attachments/assets/56032151-bc65-4a73-8ca3-e8124c77f2e9


