### PR TITLE
[Refactor] promise.all로 동시에 비동기 처리 요청

### DIFF
--- a/apps/api/src/modules/feed/feed.service.ts
+++ b/apps/api/src/modules/feed/feed.service.ts
@@ -33,23 +33,27 @@ export class FeedService {
     let { followingLimit, trendingLimit, recentLimit } =
       this.sourceAllocationPolicy.allocate(limit);
 
+    // todo promise.all로 묶기
     // 팔로잉 글 (+ 내 글)
-    const { posts: followingPosts, nextCursor: nextFollowingCursor } =
+    // 인기 게시글
+
+    const [
+      { posts: followingPosts, nextCursor: nextFollowingCursor },
+      { posts: trendingPosts, nextCursor: nextTrendingCursor },
+    ] = await Promise.all([
       await this.followingSource.getPosts(
         isInitialRequest,
         requestUserId,
         followingLimit,
         cursor?.following,
-      );
-
-    // 인기 게시글
-    const { posts: trendingPosts, nextCursor: nextTrendingCursor } =
+      ),
       await this.trendingSource.getPosts(
         isInitialRequest,
         requestUserId,
         trendingLimit,
         cursor?.trending,
-      );
+      ),
+    ]);
 
     // 덜 조회된 팔로잉 글 수만큼 최신글을 더 조회
     const followingShortage = followingLimit - followingPosts.length;


### PR DESCRIPTION

## 🚀 PR 개요

- feed service에서 팔로잉글, 인기글 조회를 promise.all로 묶어서 요청
- 최신글은 팔로잉 결과에 따라 조회 요청 수가 달라져서 포함 X

## 🔗 관련 이슈

## 🔍 작업 내용


## ✔ 주요 고민과 해결 과정

## 📝 참고문서, 학습정리(선택)

## 기타
