### PR TITLE
[Feat] 게시글 미디어 UX 및 피드 레이아웃 개선

### DIFF
--- a/apps/web/src/components/feed/FeedList.tsx
+++ b/apps/web/src/components/feed/FeedList.tsx
@@ -14,6 +14,8 @@ export default function FeedList({ posts }: FeedListProps) {
   const router = useRouter();
 
   const playMusic = usePlayerStore((s) => s.playMusic);
+  const addToQueue = usePlayerStore((s) => s.addToQueue);
+  const selectMusic = usePlayerStore((s) => s.selectMusic);
   const currentMusicId = usePlayerStore((s) => s.currentMusic?.id ?? null);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
 
@@ -21,6 +23,15 @@ export default function FeedList({ posts }: FeedListProps) {
 
   const handlePlay = (music: Music) => {
     playMusic(music);
+  };
+
+  const handlePlayAll = (post: Post) => {
+    const musics = post.musics;
+    if (!musics.length) return;
+    const firstMusic = musics[0];
+    if (!firstMusic) return;
+    addToQueue(musics);
+    selectMusic(firstMusic);
   };
 
   const handleUserClick = (userId: string) => {
@@ -40,6 +51,7 @@ export default function FeedList({ posts }: FeedListProps) {
               key={post.id}
               post={post}
               onPlay={handlePlay}
+              onPlayAll={() => handlePlayAll(post)}
               onUserClick={handleUserClick}
               onOpenDetail={handleOpenDetail}
               currentMusicId={currentMusicId}

--- a/apps/web/src/components/feed/FeedList.tsx
+++ b/apps/web/src/components/feed/FeedList.tsx
@@ -44,7 +44,7 @@ export default function FeedList({ posts }: FeedListProps) {
 
   return (
     <div className="flex-1 p-4 md:p-8 max-xs:px-0">
-      <div className="max-w-2xl mx-auto">
+      <div className="max-w-lg mx-auto">
         <div className="space-y-4">
           {posts.map((post) => (
             <PostCard

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -1,17 +1,32 @@
 'use client';
 
+import { usePathname, useRouter } from 'next/navigation';
 import { Bell } from 'lucide-react';
 
 import { useNotiStore } from '@/stores/useNotiStore';
 import { useNotiOverlayStore } from '@/stores/useNotiOverlayStore';
+import { useFeedRefreshStore } from '@/stores';
 
 export default function Header() {
+  const pathname = usePathname();
+  const router = useRouter();
   const unreadNotiCount = useNotiStore((s) => s.unreadCount);
   const openNoti = useNotiOverlayStore((s) => s.open);
+  const bumpFeed = useFeedRefreshStore((s) => s.bump);
+
+  const handleLogoClick = () => {
+    if (pathname === '/') {
+      bumpFeed();
+    } else {
+      router.push('/');
+    }
+  };
 
   return (
     <header className="sticky top-0 z-10 bg-white/95 backdrop-blur-sm border-b-2 border-primary px-6 py-4 flex items-center justify-between">
-      <h1 className="text-2xl font-black italic tracking-tighter text-primary uppercase">VIBR</h1>
+      <button type="button" onClick={handleLogoClick} className="text-2xl font-black italic tracking-tighter text-primary uppercase">
+        VIBR
+      </button>
 
       {/* 모바일 전용 알림 버튼 */}
       <button

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -1,20 +1,17 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
 import { Bell } from 'lucide-react';
 
 import { useNotiStore } from '@/stores/useNotiStore';
 import { useNotiOverlayStore } from '@/stores/useNotiOverlayStore';
 
 export default function Header() {
-  const pathname = usePathname();
-  const pageTitle = pathname === '/' ? 'feed' : pathname.split('/')[1];
   const unreadNotiCount = useNotiStore((s) => s.unreadCount);
   const openNoti = useNotiOverlayStore((s) => s.open);
 
   return (
     <header className="sticky top-0 z-10 bg-white/95 backdrop-blur-sm border-b-2 border-primary px-6 py-4 flex items-center justify-between">
-      <h1 className="text-2xl font-black italic tracking-tighter text-primary uppercase">{pageTitle}</h1>
+      <h1 className="text-2xl font-black italic tracking-tighter text-primary uppercase">VIBR</h1>
 
       {/* 모바일 전용 알림 버튼 */}
       <button

--- a/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx
+++ b/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx
@@ -290,7 +290,7 @@ export const PostCardDetailModal = () => {
         aria-modal="true"
       >
         <div
-          className="bg-white w-full max-w-5xl h-full max-h-[85vh] rounded-2xl border-2 border-primary shadow-2xl flex flex-col md:flex-row overflow-hidden animate-scale-up"
+          className="bg-white w-full max-w-[1640px] h-full max-h-[85vh] rounded-2xl border-2 border-primary shadow-2xl flex flex-col md:flex-row overflow-hidden animate-scale-up"
           onClick={(e) => e.stopPropagation()}
         >
           {isLoading ? (

--- a/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx
+++ b/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx
@@ -67,6 +67,8 @@ export const PostCardDetailModal = () => {
   });
 
   const playMusic = usePlayerStore((s) => s.playMusic);
+  const addToQueue = usePlayerStore((s) => s.addToQueue);
+  const selectMusic = usePlayerStore((s) => s.selectMusic);
   const currentMusicId = usePlayerStore((s) => s.currentMusic?.id ?? null);
   const currentMusic = usePlayerStore((s) => s.currentMusic); // UX
   const isPlaying = usePlayerStore((s) => s.isPlaying);
@@ -158,6 +160,17 @@ export const PostCardDetailModal = () => {
     },
     [playMusic],
   );
+
+  // 커버 페이지: 게시글 전체 음악을 큐에 넣고 첫 번째 곡 재생
+  const handlePlayAll = useCallback(() => {
+    const musics = safePost.musics;
+    if (!musics.length) return;
+    const firstMusic = musics[0];
+    if (!firstMusic) return;
+    addToQueue(musics);
+    playedMusicIdsRef.current.add(firstMusic.id);
+    selectMusic(firstMusic);
+  }, [safePost.musics, addToQueue, selectMusic]);
 
   // listen time 누적(1초 tick)
   useEffect(() => {
@@ -300,7 +313,14 @@ export const PostCardDetailModal = () => {
               <div className="text-sm font-bold text-gray-500">{error}</div>
             </div>
           ) : (
-            <PostMedia post={safePost} variant="modal" currentMusicId={currentMusicId} isPlayingGlobal={isPlaying} onPlay={handlePlayFromPost} />
+            <PostMedia
+              post={safePost}
+              variant="modal"
+              currentMusicId={currentMusicId}
+              isPlayingGlobal={isPlaying}
+              onPlay={handlePlayFromPost}
+              onPlayAll={handlePlayAll}
+            />
           )}
 
           <div className="w-full md:w-105 flex flex-col bg-white border-l-2 border-primary flex-1 min-h-0">

--- a/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx
+++ b/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx
@@ -303,7 +303,7 @@ export const PostCardDetailModal = () => {
         aria-modal="true"
       >
         <div
-          className="bg-white w-full max-w-[1640px] h-full max-h-[85vh] rounded-2xl border-2 border-primary shadow-2xl flex flex-col md:flex-row overflow-hidden animate-scale-up"
+          className="bg-white w-full max-w-5xl h-full max-h-[85vh] rounded-2xl border-2 border-primary shadow-2xl flex flex-col md:flex-row overflow-hidden animate-scale-up"
           onClick={(e) => e.stopPropagation()}
         >
           {isLoading ? (

--- a/apps/web/src/components/post/PostCard.tsx
+++ b/apps/web/src/components/post/PostCard.tsx
@@ -16,11 +16,12 @@ interface PostCardProps {
   isPlayingGlobal: boolean;
 
   onPlay: (music: Music) => void;
+  onPlayAll?: () => void;
   onUserClick: (userId: string) => void;
   onOpenDetail: (post: Post) => void;
 }
 
-export default function PostCard({ post, currentMusicId, isPlayingGlobal, onPlay, onUserClick, onOpenDetail }: PostCardProps) {
+export default function PostCard({ post, currentMusicId, isPlayingGlobal, onPlay, onPlayAll, onUserClick, onOpenDetail }: PostCardProps) {
   const userId = useAuthStore((s) => s.userId);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const { openModal } = useModalStore();
@@ -113,6 +114,7 @@ export default function PostCard({ post, currentMusicId, isPlayingGlobal, onPlay
         currentMusicId={currentMusicId}
         isPlayingGlobal={isPlayingGlobal}
         onPlay={onPlay}
+        onPlayAll={onPlayAll}
         onClickContainer={handleOpenDetail}
       />
 

--- a/apps/web/src/components/post/PostCard.tsx
+++ b/apps/web/src/components/post/PostCard.tsx
@@ -107,16 +107,17 @@ export default function PostCard({ post, currentMusicId, isPlayingGlobal, onPlay
         <PostHeader post={post} isOwner={isOwner} onUserClick={onUserClick} onEditPost={isOwner ? openEditPostModal : undefined} />
       </div>
 
-      {/* 이미지: 패딩 없이 카드 너비 전체를 채움 (xs 미만에서는 FeedList px-0 덕분에 화면 끝까지) */}
-      <PostMedia
-        post={post}
-        variant="card"
-        currentMusicId={currentMusicId}
-        isPlayingGlobal={isPlayingGlobal}
-        onPlay={onPlay}
-        onPlayAll={onPlayAll}
-        onClickContainer={handleOpenDetail}
-      />
+      <div className="xs:px-4 sm:px-6">
+        <PostMedia
+          post={post}
+          variant="card"
+          currentMusicId={currentMusicId}
+          isPlayingGlobal={isPlayingGlobal}
+          onPlay={onPlay}
+          onPlayAll={onPlayAll}
+          onClickContainer={handleOpenDetail}
+        />
+      </div>
 
       <div className="px-4 sm:px-6">
         <PostActions

--- a/apps/web/src/components/post/partials/PostMedia.tsx
+++ b/apps/web/src/components/post/partials/PostMedia.tsx
@@ -258,11 +258,18 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
         </div>
       )}
 
-      {activeMusic && (
-        <div className={`${styles.infoBox} max-w-[70%] md:max-w-[60%] min-w-0`}>
-          <TickerText text={activeMusic.title} className="text-sm md:text-base font-black text-primary" />
-          <TickerText text={activeMusic.artistName} className="text-xs font-bold text-gray-600" />
+      {isCoverPage && post.musics.length > 0 && onPlayAll ? (
+        <div className={`${styles.infoBox} min-w-0`}>
+          <span className="text-sm md:text-base font-black text-primary">전체 재생</span>
+          <p className="text-xs font-bold text-gray-600">{post.musics.length}곡</p>
         </div>
+      ) : (
+        activeMusic && (
+          <div className={`${styles.infoBox} max-w-[70%] md:max-w-[60%] min-w-0`}>
+            <TickerText text={activeMusic.title} className="text-sm md:text-base font-black text-primary" />
+            <TickerText text={activeMusic.artistName} className="text-xs font-bold text-gray-600" />
+          </div>
+        )
       )}
     </div>
   );

--- a/apps/web/src/components/post/partials/PostMedia.tsx
+++ b/apps/web/src/components/post/partials/PostMedia.tsx
@@ -161,20 +161,54 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
       {/* 이미지 슬라이드 트랙 */}
       {isMulti ? (
         <div className="flex h-full w-[300%]" style={trackStyle}>
-          <div className="w-1/3 h-full flex-shrink-0">
-            <img src={prevUrl} alt="이전" className="w-full h-full object-cover" />
+          <div className="w-1/3 h-full flex-shrink-0 relative">
+            {variant === 'modal' ? (
+              <>
+                <img src={prevUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
+                <img src={prevUrl} alt="이전" className="absolute inset-0 w-full h-full object-contain" />
+              </>
+            ) : (
+              <img src={prevUrl} alt="이전" className="w-full h-full object-cover" />
+            )}
           </div>
-          <div className="w-1/3 h-full flex-shrink-0">
-            <img
-              src={coverUrl}
-              alt={activeMusic?.title ?? 'cover'}
-              className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-            />
+          <div className="w-1/3 h-full flex-shrink-0 relative">
+            {variant === 'modal' ? (
+              <>
+                <img src={coverUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
+                <img
+                  src={coverUrl}
+                  alt={activeMusic?.title ?? 'cover'}
+                  className="absolute inset-0 w-full h-full object-contain transition-transform duration-500 group-hover:scale-105"
+                />
+              </>
+            ) : (
+              <img
+                src={coverUrl}
+                alt={activeMusic?.title ?? 'cover'}
+                className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+              />
+            )}
           </div>
-          <div className="w-1/3 h-full flex-shrink-0">
-            <img src={nextUrl} alt="다음" className="w-full h-full object-cover" />
+          <div className="w-1/3 h-full flex-shrink-0 relative">
+            {variant === 'modal' ? (
+              <>
+                <img src={nextUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
+                <img src={nextUrl} alt="다음" className="absolute inset-0 w-full h-full object-contain" />
+              </>
+            ) : (
+              <img src={nextUrl} alt="다음" className="w-full h-full object-cover" />
+            )}
           </div>
         </div>
+      ) : variant === 'modal' ? (
+        <>
+          <img src={coverUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
+          <img
+            src={coverUrl}
+            alt={activeMusic?.title ?? 'cover'}
+            className="absolute inset-0 w-full h-full object-contain transition-transform duration-500 group-hover:scale-105"
+          />
+        </>
       ) : (
         <img
           src={coverUrl}

--- a/apps/web/src/components/post/partials/PostMedia.tsx
+++ b/apps/web/src/components/post/partials/PostMedia.tsx
@@ -67,8 +67,8 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
     if (i === 0) return post.coverImgUrl || '';
     return post.musics[i - 1]?.albumCoverUrl || post.coverImgUrl || '';
   };
-  const prevUrl = isMulti ? getSlideUrl(activeIndex - 1) : '';
-  const nextUrl = isMulti ? getSlideUrl(activeIndex + 1) : '';
+  const prevUrl = isMulti && activeIndex > 0 ? getSlideUrl(activeIndex - 1) : '';
+  const nextUrl = isMulti && activeIndex < totalLength - 1 ? getSlideUrl(activeIndex + 1) : '';
 
   const handlePlay = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
@@ -107,6 +107,9 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
     if (!isMulti || transitioning) return;
     const delta = (e.touches[0]?.clientX ?? 0) - touchStartX.current;
     if (Math.abs(delta) > 5) wasSwipeRef.current = true;
+    // 경계에서 해당 방향 스와이프 막기
+    if (activeIndex <= 0 && delta > 0) return;
+    if (activeIndex >= totalLength - 1 && delta < 0) return;
     setDragOffset(delta);
   };
 
@@ -124,7 +127,10 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
 
     setTransitioning(true);
 
-    if (delta < -threshold) {
+    const isAtStart = activeIndex <= 0;
+    const isAtEnd = activeIndex >= totalLength - 1;
+
+    if (delta < -threshold && !isAtEnd) {
       // 왼쪽 스와이프 → 다음
       setDragOffset(-containerWidth);
       setTimeout(() => {
@@ -132,7 +138,7 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
         setTransitioning(false);
         setDragOffset(0);
       }, 250);
-    } else if (delta > threshold) {
+    } else if (delta > threshold && !isAtStart) {
       // 오른쪽 스와이프 → 이전
       setDragOffset(containerWidth);
       setTimeout(() => {
@@ -169,14 +175,15 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
       {isMulti ? (
         <div className="flex h-full w-[300%]" style={trackStyle}>
           <div className="w-1/3 h-full flex-shrink-0 relative overflow-hidden">
-            {variant === 'modal' ? (
-              <>
-                <img src={prevUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
-                <img src={prevUrl} alt="이전" className="absolute inset-0 w-full h-full object-contain" />
-              </>
-            ) : (
-              <img src={prevUrl} alt="이전" className="w-full h-full object-cover" />
-            )}
+            {prevUrl &&
+              (variant === 'modal' ? (
+                <>
+                  <img src={prevUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
+                  <img src={prevUrl} alt="이전" className="absolute inset-0 w-full h-full object-contain" />
+                </>
+              ) : (
+                <img src={prevUrl} alt="이전" className="w-full h-full object-cover" />
+              ))}
           </div>
           <div className="w-1/3 h-full flex-shrink-0 relative overflow-hidden">
             {variant === 'modal' ? (
@@ -197,14 +204,15 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
             )}
           </div>
           <div className="w-1/3 h-full flex-shrink-0 relative overflow-hidden">
-            {variant === 'modal' ? (
-              <>
-                <img src={nextUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
-                <img src={nextUrl} alt="다음" className="absolute inset-0 w-full h-full object-contain" />
-              </>
-            ) : (
-              <img src={nextUrl} alt="다음" className="w-full h-full object-cover" />
-            )}
+            {nextUrl &&
+              (variant === 'modal' ? (
+                <>
+                  <img src={nextUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
+                  <img src={nextUrl} alt="다음" className="absolute inset-0 w-full h-full object-contain" />
+                </>
+              ) : (
+                <img src={nextUrl} alt="다음" className="w-full h-full object-cover" />
+              ))}
           </div>
         </div>
       ) : variant === 'modal' ? (
@@ -242,12 +250,16 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
         )}
         {isMulti && (
           <>
-            <button type="button" onClick={handlePrev} className={`${styles.navBtn} left-3`} title="이전">
-              <ChevronLeft className="w-6 h-6" />
-            </button>
-            <button type="button" onClick={handleNext} className={`${styles.navBtn} right-3`} title="다음">
-              <ChevronRight className="w-6 h-6" />
-            </button>
+            {activeIndex > 0 && (
+              <button type="button" onClick={handlePrev} className={`${styles.navBtn} left-3`} title="이전">
+                <ChevronLeft className="w-6 h-6" />
+              </button>
+            )}
+            {activeIndex < totalLength - 1 && (
+              <button type="button" onClick={handleNext} className={`${styles.navBtn} right-3`} title="다음">
+                <ChevronRight className="w-6 h-6" />
+              </button>
+            )}
           </>
         )}
       </div>

--- a/apps/web/src/components/post/partials/PostMedia.tsx
+++ b/apps/web/src/components/post/partials/PostMedia.tsx
@@ -16,6 +16,8 @@ type Props = {
   isPlayingGlobal: boolean;
 
   onPlay: (music: Music) => void;
+  /** 커버 페이지 재생 버튼: 게시글 전체 음악 재생 */
+  onPlayAll?: () => void;
 
   /** 카드에서만: 컨테이너 클릭 시 상세 열기 */
   onClickContainer?: () => void;
@@ -43,7 +45,7 @@ const stylesByVariant: Record<Variant, { container: string; playBtn: string; inf
   },
 };
 
-export default function PostMedia({ post, variant, currentMusicId, isPlayingGlobal, onPlay, onClickContainer }: Props) {
+export default function PostMedia({ post, variant, currentMusicId, isPlayingGlobal, onPlay, onPlayAll, onClickContainer }: Props) {
   const { isMulti, activeMusic, coverUrl, isActivePlaying, prev, next, activeIndex, totalLength } = usePostMedia({
     post,
     currentMusicId,
@@ -72,6 +74,11 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
     e.stopPropagation();
     if (!activeMusic) return;
     onPlay(activeMusic);
+  };
+
+  const handlePlayAll = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onPlayAll?.();
   };
 
   const handlePrev = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -219,6 +226,13 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
 
       {/* 오버레이 (버튼, 배지, 음악 정보) */}
       <div className="absolute inset-0 bg-black/10 group-hover:bg-black/35 transition-colors">
+        {isCoverPage && post.musics.length > 0 && onPlayAll && (
+          <div className="absolute inset-0 flex items-center justify-center opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+            <button type="button" onClick={handlePlayAll} className={styles.playBtn} title="전체 재생">
+              <Play className="w-6 h-6 ml-0.5" />
+            </button>
+          </div>
+        )}
         {!isCoverPage && activeMusic && (
           <div className="absolute inset-0 flex items-center justify-center opacity-100 md:group-hover:opacity-100 transition-opacity">
             <button type="button" onClick={handlePlay} className={styles.playBtn} title={isActivePlaying ? '일시정지' : '재생'}>

--- a/apps/web/src/components/post/partials/PostMedia.tsx
+++ b/apps/web/src/components/post/partials/PostMedia.tsx
@@ -161,7 +161,7 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
       {/* 이미지 슬라이드 트랙 */}
       {isMulti ? (
         <div className="flex h-full w-[300%]" style={trackStyle}>
-          <div className="w-1/3 h-full flex-shrink-0 relative">
+          <div className="w-1/3 h-full flex-shrink-0 relative overflow-hidden">
             {variant === 'modal' ? (
               <>
                 <img src={prevUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
@@ -171,7 +171,7 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
               <img src={prevUrl} alt="이전" className="w-full h-full object-cover" />
             )}
           </div>
-          <div className="w-1/3 h-full flex-shrink-0 relative">
+          <div className="w-1/3 h-full flex-shrink-0 relative overflow-hidden">
             {variant === 'modal' ? (
               <>
                 <img src={coverUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
@@ -189,7 +189,7 @@ export default function PostMedia({ post, variant, currentMusicId, isPlayingGlob
               />
             )}
           </div>
-          <div className="w-1/3 h-full flex-shrink-0 relative">
+          <div className="w-1/3 h-full flex-shrink-0 relative overflow-hidden">
             {variant === 'modal' ? (
               <>
                 <img src={nextUrl} alt="" aria-hidden className="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />

--- a/apps/web/src/components/post/partials/PostMedia.tsx
+++ b/apps/web/src/components/post/partials/PostMedia.tsx
@@ -25,7 +25,7 @@ type Props = {
 
 const stylesByVariant: Record<Variant, { container: string; playBtn: string; infoBox: string; navBtn: string }> = {
   card: {
-    container: 'relative group w-full aspect-square overflow-hidden xs:rounded-xl mb-4 bg-gray-100',
+    container: 'relative group w-full aspect-square overflow-hidden xs:rounded-md mb-4 bg-gray-100',
     playBtn: 'w-12 aspect-square rounded-full bg-primary text-white flex items-center justify-center shadow-[2px_2px_0px_0px_#00ebc7]',
     infoBox:
       'absolute max-w-4/5 bottom-4 left-4 bg-white/90 backdrop-blur-sm px-4 py-2 rounded-lg border-2 border-primary shadow-[4px_4px_0px_0px_#FDE24F]',

--- a/apps/web/src/components/profile/ProfilePostsFeed.tsx
+++ b/apps/web/src/components/profile/ProfilePostsFeed.tsx
@@ -21,6 +21,8 @@ export default function ProfilePostsFeed({ userId, initialPostId }: Props) {
   const router = useRouter();
   const openModal = useModalStore((s) => s.openModal);
   const playMusic = usePlayerStore((s) => s.playMusic);
+  const addToQueue = usePlayerStore((s) => s.addToQueue);
+  const selectMusic = usePlayerStore((s) => s.selectMusic);
   const currentMusicId = usePlayerStore((s) => s.currentMusic?.id ?? null);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
 
@@ -72,6 +74,14 @@ export default function ProfilePostsFeed({ userId, initialPostId }: Props) {
   }, [isMobile, userId, initialPostId, openModal, router]);
 
   const handlePlay = (music: Music) => playMusic(music);
+  const handlePlayAll = (post: Post) => {
+    const musics = post.musics;
+    if (!musics.length) return;
+    const firstMusic = musics[0];
+    if (!firstMusic) return;
+    addToQueue(musics);
+    selectMusic(firstMusic);
+  };
   const handleUserClick = (uid: string) => router.push(`/profile/${uid}`);
   const handleOpenDetail = (post: Post) => openModal(MODAL_TYPES.POST_DETAIL, { postId: post.id, post });
 
@@ -148,6 +158,7 @@ export default function ProfilePostsFeed({ userId, initialPostId }: Props) {
                 <PostCard
                   post={post}
                   onPlay={handlePlay}
+                  onPlayAll={() => handlePlayAll(post)}
                   onUserClick={handleUserClick}
                   onOpenDetail={handleOpenDetail}
                   currentMusicId={currentMusicId}

--- a/apps/web/src/components/sidebar/Drawer.tsx
+++ b/apps/web/src/components/sidebar/Drawer.tsx
@@ -9,6 +9,7 @@ import { DRAWER_LEFT_EXPANDED, DRAWER_LEFT_SHRINKED } from '@/constants';
 type DrawerProps = PropsWithChildren<{
   isOpen: boolean;
   isSidebarExpanded: boolean;
+  title?: string;
 
   /** Suspense fallback (옵션) */
   loadingFallback?: ReactNode;
@@ -17,7 +18,7 @@ type DrawerProps = PropsWithChildren<{
   errorFallback?: ReactNode;
 }>;
 
-export default function Drawer({ isOpen, isSidebarExpanded, children, loadingFallback = <LoadingSpinner /> }: DrawerProps) {
+export default function Drawer({ isOpen, isSidebarExpanded, title, children, loadingFallback = <LoadingSpinner /> }: DrawerProps) {
   return (
     <div
       className={`
@@ -26,6 +27,11 @@ export default function Drawer({ isOpen, isSidebarExpanded, children, loadingFal
         ${isOpen ? 'translate-x-0' : '-translate-x-full opacity-0 pointer-events-none'}
       `}
     >
+      {title && (
+        <div className="px-6 py-4 border-b-2 border-primary flex-shrink-0">
+          <h2 className="text-xl font-black text-primary">{title}</h2>
+        </div>
+      )}
       <ErrorBoundary FallbackComponent={ErrorScreen}>
         <Suspense fallback={loadingFallback}>{children}</Suspense>
       </ErrorBoundary>

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -230,12 +230,12 @@ export default function Sidebar() {
       </nav>
 
       {/* 1. 검색 */}
-      <Drawer isOpen={isSearchOpen} isSidebarExpanded={isExpanded}>
+      <Drawer isOpen={isSearchOpen} isSidebarExpanded={isExpanded} title="검색">
         <SearchDrawerContent enabled={isSearchOpen} />
       </Drawer>
 
       {/* 2. 알림 */}
-      <Drawer isOpen={isNotificationOpen} isSidebarExpanded={isExpanded}>
+      <Drawer isOpen={isNotificationOpen} isSidebarExpanded={isExpanded} title="알림">
         <NotiDrawerContent />
       </Drawer>
     </div>

--- a/apps/web/src/hooks/post/usePostMedia.ts
+++ b/apps/web/src/hooks/post/usePostMedia.ts
@@ -32,13 +32,13 @@ export function usePostMedia({ post, currentMusicId, isPlayingGlobal }: Args) {
 
   const prev = useCallback(() => {
     if (!isMulti) return;
-    setActiveIndex((prevIdx) => (prevIdx - 1 < 0 ? totalLength - 1 : prevIdx - 1));
-  }, [isMulti, post.musics.length]);
+    setActiveIndex((prevIdx) => (prevIdx <= 0 ? 0 : prevIdx - 1));
+  }, [isMulti]);
 
   const next = useCallback(() => {
     if (!isMulti) return;
-    setActiveIndex((prevIdx) => (prevIdx + 1) % totalLength);
-  }, [isMulti, post.musics.length]);
+    setActiveIndex((prevIdx) => (prevIdx >= totalLength - 1 ? totalLength - 1 : prevIdx + 1));
+  }, [isMulti, totalLength]);
 
   return {
     activeIndex,


### PR DESCRIPTION
## 🚀 PR 개요

소소한 ui 디테일 수정을 했습니다.
구체적인 내용으로는
- 게시글 이미지에서 끝 <-> 처음 이동을 막음
- 게시글 상세 모달에서 앨범 커버가 다 나오게
- 게시글 첫번째 이미지 재생 버튼 클릭하면 전체 재생 되도록
- 피드에서 게시글 너비 조정, border radius 조정
- 홈, 보관함, 프로필 페이지에서 헤더에 각 페이지 말고 VIBR 가 나타나도록, 클릭하면 홈으로 이동/피드 새로고침 되도록
- 알림, 검색 드로어에 "알림", "검색"이라고 헤더 표시 (제가 이전에 모바일 ui 작업하다가 없앴던 부분)

이렇게 됩니다.


## 🔍 작업 내용

1. 게시글 이미지 슬라이더 경계 처리
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/01903eb7-910c-4a48-b0dd-638a63692503" />

- 파일: [PostMedia.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/post/partials/PostMedia.tsx), [usePostMedia.ts](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/hooks/post/usePostMedia.ts)
- 첫 번째 이미지에서 이전, 마지막 이미지에서 다음으로 넘어가는 루프 제거 (순환 → 양끝 고정)
- 경계에서 네비게이션 버튼(<, >) 숨김
- 경계에서 스와이프 제스처 차단

2. 게시글 상세 모달 이미지 영역 개선
- 현재 (정사각형 모양의 앨범 커버가 잘려서 보임)
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/6a7c285b-1b5f-490c-a261-e392f5913939" />

- 수정 후 (앨범 커버가 다 보임)
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/0f06225a-e617-48b6-a40c-4de3e2275a29" />


- 파일: [PostMedia.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/post/partials/PostMedia.tsx), [PostCardDetailModal.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx)
- modal variant에서 이미지에 블러 배경 효과 적용 (배경 blur + 전경 object-contain)
- 상세 모달 최대 너비 max-w-5xl → max-w-[1640px]으로 확장 (이미지 영역 가로 확대)

3. 커버 페이지 전체 재생 기능
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/01903eb7-910c-4a48-b0dd-638a63692503" />

- 파일: [PostMedia.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/post/partials/PostMedia.tsx), [PostCard.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/post/PostCard.tsx), [FeedList.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/feed/FeedList.tsx), [ProfilePostsFeed.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/profile/ProfilePostsFeed.tsx), [PostCardDetailModal.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/modals/PostCardDetailModal/PostCardDetailModal.tsx)
- 슬라이더 첫 번째 슬라이드(커버 페이지)에 전체 재생 버튼 추가
- 클릭 시 게시글의 모든 음악을 큐에 추가하고 첫 번째 곡 재생
- 커버 페이지일 때 infoBox에 "전체 재생 / N곡" 표시

4. 피드 레이아웃 조정
- 왼쪽이 수정 후, 오른쪽이 현재
  <img width="3420" height="2214" alt="image" src="https://github.com/user-attachments/assets/e2f8bfa6-447b-46d0-8eca-4409b307ccc8" />

- 파일: [FeedList.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/feed/FeedList.tsx), [PostCard.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/post/PostCard.tsx)
- 피드 최대 너비 max-w-2xl → max-w-lg로 축소
- 게시글 이미지에 좌우 패딩 추가 (xs:px-4 sm:px-6) → 카드 내부로 들어오도록
- 이미지 border-radius rounded-xl → rounded-md로 줄임

5. 헤더 VIBR 클릭 동작
- 파일: [Header.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/layout/Header.tsx)
- 헤더 타이틀을 현재 경로 기반 텍스트 → 항상 "VIBR" 고정
- 홈(/)에서 클릭 시 피드 새로고침 (bumpFeed)
- 다른 페이지에서 클릭 시 홈으로 이동

6. 드로어 헤더 추가
- 파일: [Drawer.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/sidebar/Drawer.tsx), [Sidebar.tsx](https://github.com/boostcampwm2025/web17-Busy/blob/feat/ui/apps/web/src/components/sidebar/Sidebar.tsx)
- Drawer에 title prop 추가
- 검색 드로어에 "검색", 알림 드로어에 "알림" 헤더 표시

## ✔ 주요 고민과 해결 과정

## 📝 참고문서, 학습정리(선택)

## 기타
