### PR TITLE
[Feat] 사이드바 드로어 UX 개선 및 레이아웃/임시 기능 정리

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -28,10 +28,23 @@
   }
 }
 
+/* ⚠️ 리캡 기능 구현 이후 삭제 예정 - 리캡 '준비중' 둥실 안내용 */
+@keyframes float-up {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(-24px);
+    opacity: 0;
+  }
+}
+
 @theme {
   --animate-slide-up: slide-up 0.3s ease-out;
   --animate-fade-in: fade-in 0.2s ease-out;
   --animate-slide-in-right: slide-in-right 0.3s ease-out;
+  --animate-float-up: float-up 1.8s ease-out forwards; /* ⚠️ 리캡 기능 구현 이후 삭제 예정 */
 
   --color-primary: #00214d;
   --color-accent-cyan: #00ebc7;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
         <NotiPollingGate />
 
         <ToastProvider>
-          <div className="flex h-screen">
+          <div className="flex h-dvh overflow-hidden">
             {/* 좌측 사이드바 (데스크탑 전용) */}
             <div className="hidden lg:flex h-full">
               <Sidebar />

--- a/apps/web/src/components/ConfirmOverlay.tsx
+++ b/apps/web/src/components/ConfirmOverlay.tsx
@@ -38,7 +38,7 @@ export default function ConfirmOverlay({
   if (!open) return null;
 
   const overlay = (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/30" onClick={onCancel}>
+    <div data-drawer-keep className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/30" onClick={onCancel}>
       <div
         ref={ref}
         className="w-[280px] bg-white border-2 border-primary rounded-lg shadow-[4px_4px_0px_0px_#00214D] p-4"

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -23,7 +23,7 @@ export default function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-10 bg-white/95 backdrop-blur-sm border-b-2 border-primary px-6 py-4 flex items-center justify-between">
+    <header className="sticky top-0 z-10 bg-white/95 backdrop-blur-sm border-b-2 border-primary px-6 h-16 flex items-center justify-between">
       <button type="button" onClick={handleLogoClick} className="text-2xl font-black italic tracking-tighter text-primary uppercase">
         VIBR
       </button>

--- a/apps/web/src/components/modals/LoginModal/LoginModal.tsx
+++ b/apps/web/src/components/modals/LoginModal/LoginModal.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useModalStore } from '@/stores/useModalStore';
 import { X } from 'lucide-react';
 import { getAuthErrorMessage } from '@/hooks/auth/client/authErrorMessage';
-import { GoogleLoginButton } from './loginButtons';
+import { GoogleLoginButton, TmpLoginButton } from './loginButtons';
 
 type LoginModalProps = {
   authError?: string;
@@ -38,6 +38,7 @@ export const LoginModal = () => {
           )}
           <GoogleLoginButton />
           {/* <SpotifyLoginButton /> */}
+          {process.env.NODE_ENV !== 'production' && <TmpLoginButton />}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/modals/LoginModal/loginButtons/TmpLoginButton.tsx
+++ b/apps/web/src/components/modals/LoginModal/loginButtons/TmpLoginButton.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useState } from 'react';
+import { tmpLogin } from '@/api/internal/auth';
+import { APP_ACCESS_TOKEN_STORAGE_KEY } from '@/constants/auth';
+
+// DEV 전용 시드 유저 (apps/api SEED_USERS와 동일)
+const DEV_USERS = [
+  { id: '019be163-4b37-76ad-aeb3-6986a3489de6', label: '테스트 사용자 1' },
+  { id: '019be163-4b3a-7619-a3cd-75302c5451e6', label: '테스트 사용자 2' },
+] as const;
+
+export const TmpLoginButton = () => {
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+
+  const handleTmpLogin = async (userId: string) => {
+    if (loadingId) return;
+    setLoadingId(userId);
+
+    try {
+      const appJwt = await tmpLogin(userId);
+      sessionStorage.setItem(APP_ACCESS_TOKEN_STORAGE_KEY, appJwt);
+      // Google 로그인과 동일하게 리로드로 인증 상태 재평가
+      window.location.assign('/');
+    } catch {
+      setLoadingId(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-dashed border-primary/30 pt-4">
+      <span className="text-xs font-bold text-secondary">DEV 임시 로그인</span>
+      {DEV_USERS.map((user) => (
+        <button
+          key={user.id}
+          type="button"
+          onClick={() => handleTmpLogin(user.id)}
+          disabled={loadingId !== null}
+          aria-busy={loadingId === user.id}
+          className="
+            w-full flex items-center justify-center gap-3
+            px-6 py-3 rounded-full font-bold text-sm
+            border border-dashed border-primary
+            bg-white text-primary
+            hover:bg-gray-50
+            active:scale-[0.98]
+            transition-all
+            disabled:opacity-60 disabled:cursor-not-allowed
+          "
+        >
+          {loadingId === user.id ? (
+            <>
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              로그인 중…
+            </>
+          ) : (
+            <>{user.label}로 로그인</>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/components/modals/LoginModal/loginButtons/index.ts
+++ b/apps/web/src/components/modals/LoginModal/loginButtons/index.ts
@@ -1,2 +1,3 @@
 export { GoogleLoginButton } from './GoogleLoginButton';
 export { SpotifyLoginButton } from './SpotifyLoginButton';
+export { TmpLoginButton } from './TmpLoginButton';

--- a/apps/web/src/components/noti/NotiDrawerContent.tsx
+++ b/apps/web/src/components/noti/NotiDrawerContent.tsx
@@ -8,7 +8,7 @@ import { MODAL_TYPES, useModalStore } from '@/stores';
 import { useRouter } from 'next/navigation';
 import { useNotiStore } from '@/stores/useNotiStore';
 
-export default function NotiDrawerContent() {
+export default function NotiDrawerContent({ onNavigate }: { onNavigate?: () => void }) {
   const openModal = useModalStore((s) => s.openModal);
   const router = useRouter();
 
@@ -30,6 +30,7 @@ export default function NotiDrawerContent() {
     }
 
     if (noti.relatedType === 'user') {
+      onNavigate?.();
       router.push(`/profile/${noti.relatedId}`);
       return;
     }

--- a/apps/web/src/components/profile/ProfileInfo/ProfileActionButton.tsx
+++ b/apps/web/src/components/profile/ProfileInfo/ProfileActionButton.tsx
@@ -43,14 +43,16 @@ export default function ProfileActionButton({
 
   // 내 프로필이면 -> 프로필 페이지에서는 리캡 생성 버튼, 모달에서는 버튼 필요 x
   if (isMyProfile) {
-    return renderIn === 'modal' ? null : (
-      <button
-        title="프로필 리캡 생성"
-        className="text-sm xs:text-base px-4 xs:px-6 py-2 rounded-full bg-accent-yellow/90 border-2 border-primary text-primary font-bold hover:bg-accent-yellow hover:shadow-[2px_2px_0px_0px_#00214D] transition-all"
-      >
-        Recap
-      </button>
-    );
+    // 리캡 생성 버튼 임시 비활성화 (주석 처리)
+    // return renderIn === 'modal' ? null : (
+    //   <button
+    //     title="프로필 리캡 생성"
+    //     className="text-sm xs:text-base px-4 xs:px-6 py-2 rounded-full bg-accent-yellow/90 border-2 border-primary text-primary font-bold hover:bg-accent-yellow hover:shadow-[2px_2px_0px_0px_#00214D] transition-all"
+    //   >
+    //     Recap
+    //   </button>
+    // );
+    return null;
   }
 
   // isFollowing === true -> [팔로잉] 버튼, 누르면 팔로우 취소 요청

--- a/apps/web/src/components/profile/ProfileInfo/ProfileActionButton.tsx
+++ b/apps/web/src/components/profile/ProfileInfo/ProfileActionButton.tsx
@@ -23,6 +23,13 @@ export default function ProfileActionButton({
 }: ProfileActionButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
 
+  // ⚠️ 리캡 기능 구현 이후 삭제 예정 - '준비중' 안내 임시 처리
+  const [showRecapHint, setShowRecapHint] = useState(false);
+  const handleRecapClick = useCallback(() => {
+    setShowRecapHint(true);
+    setTimeout(() => setShowRecapHint(false), 1800);
+  }, []);
+
   const isLoggedIn = !!loggedInUserId;
   const isMyProfile = loggedInUserId === profileUserId;
 
@@ -43,16 +50,24 @@ export default function ProfileActionButton({
 
   // 내 프로필이면 -> 프로필 페이지에서는 리캡 생성 버튼, 모달에서는 버튼 필요 x
   if (isMyProfile) {
-    // 리캡 생성 버튼 임시 비활성화 (주석 처리)
-    // return renderIn === 'modal' ? null : (
-    //   <button
-    //     title="프로필 리캡 생성"
-    //     className="text-sm xs:text-base px-4 xs:px-6 py-2 rounded-full bg-accent-yellow/90 border-2 border-primary text-primary font-bold hover:bg-accent-yellow hover:shadow-[2px_2px_0px_0px_#00214D] transition-all"
-    //   >
-    //     Recap
-    //   </button>
-    // );
-    return null;
+    return renderIn === 'modal' ? null : (
+      <div className="relative">
+        {/* ⚠️ 리캡 기능 구현 이후 삭제 예정 - 클릭 시 '준비중' 둥실 안내 */}
+        {showRecapHint && (
+          // 바깥: 가로 중앙 정렬 / 안쪽: 위로 둥실 떠오르며 페이드아웃 (transform 충돌 방지)
+          <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1">
+            <span className="block whitespace-nowrap text-sm font-bold text-primary animate-float-up">🚧 준비중!</span>
+          </span>
+        )}
+        <button
+          onClick={handleRecapClick} // ⚠️ 리캡 기능 구현 이후 실제 리캡 생성 핸들러로 교체
+          title="프로필 리캡 생성"
+          className="text-sm xs:text-base px-4 xs:px-6 py-2 rounded-full bg-accent-yellow/90 border-2 border-primary text-primary font-bold hover:bg-accent-yellow hover:shadow-[2px_2px_0px_0px_#00214D] transition-all"
+        >
+          Recap
+        </button>
+      </div>
+    );
   }
 
   // isFollowing === true -> [팔로잉] 버튼, 누르면 팔로우 취소 요청

--- a/apps/web/src/components/sidebar/Drawer.tsx
+++ b/apps/web/src/components/sidebar/Drawer.tsx
@@ -28,7 +28,8 @@ export default function Drawer({ isOpen, isSidebarExpanded, title, children, loa
       `}
     >
       {title && (
-        <div className="px-6 py-4 border-b-2 border-primary flex-shrink-0">
+        // 높이를 중앙 Header(h-16)와 맞춰 하단 구분선 위치를 정렬 (폰트 크기는 유지)
+        <div className="px-6 h-16 flex items-center border-b-2 border-primary flex-shrink-0">
           <h2 className="text-xl font-black text-primary">{title}</h2>
         </div>
       )}

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -155,6 +155,18 @@ export default function Sidebar() {
     };
   }, [activeDrawer, handleCloseDrawer]);
 
+  useEffect(() => {
+    // ESC 키로 열린 드로어 닫기 (모달이 열려 있으면 모달 닫기가 우선)
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      if (useModalStore.getState().isOpen) return;
+      if (activeDrawer) handleCloseDrawer();
+    };
+
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [activeDrawer, handleCloseDrawer]);
+
   return (
     <div className="flex h-full relative z-30" ref={sidebarRef}>
       {/* 메뉴 버튼 영역 */}
@@ -243,7 +255,7 @@ export default function Sidebar() {
 
       {/* 2. 알림 */}
       <Drawer isOpen={isNotificationOpen} isSidebarExpanded={isExpanded} title="알림">
-        <NotiDrawerContent />
+        <NotiDrawerContent onNavigate={handleCloseDrawer} />
       </Drawer>
     </div>
   );

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -136,7 +136,14 @@ export default function Sidebar() {
   useEffect(() => {
     // 외부 영역 클릭 여부 판단 후 열린 드로어가 있다면 닫기
     const handleClickOutside = (event: MouseEvent) => {
-      if (sidebarRef.current && !sidebarRef.current.contains(event.target as Node) && activeDrawer) {
+      const target = event.target as HTMLElement;
+
+      // 포털로 띄워진 모달/오버레이 위 클릭은 바깥 클릭으로 보지 않음
+      // (sidebarRef DOM 밖이라 그냥 두면 드로어가 닫혀버림)
+      if (useModalStore.getState().isOpen) return;
+      if (target.closest('[data-drawer-keep]')) return;
+
+      if (sidebarRef.current && !sidebarRef.current.contains(target) && activeDrawer) {
         handleCloseDrawer();
       }
     };


### PR DESCRIPTION
## 🚀 PR 개요

사이드바 드로어(검색/알림) 관련 UX를 개선하고, 헤더·레이아웃 정리 및 개발/임시 기능(개발용 로그인 버튼, 리캡 준비중 안내)을 추가합니다.

## 🔗 관련 이슈

https://github.com/boostcampwm2025/web17-Busy/issues/304

## 🐞 개선한 기존 문제
- 게시글 상세 모달 / "모두 삭제" 확인 오버레이의 버튼이나 바깥 영역을 클릭하면 **좌측 드로어가 같이 닫혀버림** (포털로 렌더되어 사이드바 DOM 밖이라 "바깥 클릭"으로 오판)
- 드로어 제목부(60px)와 헤더(64px)의 **높이가 달라 하단 구분선이 어긋남**
  <img width="340" height="131" alt="image" src="https://github.com/user-attachments/assets/cfed4d3a-7a3b-4576-8b72-f4ef45c88e9d" />

- **화면 전체가 위아래로 스크롤**되어 헤더·사이드바까지 같이 움직임. 모바일에선 `100vh`가 실제 보이는 화면보다 커 더 심함 (vibr.site 가서 스크롤 해보시거나 모바일에서 접속해보시면 문제가 인식되실 겁니다.)
- 열린 드로어를 **ESC로 닫을 수 없었음**
- 알림으로 **프로필 이동 후에도 드로어가 열린 채** 새 페이지를 가림

## 🔍 작업 내용

### 🧩 드로어 UX 개선
- **모달/오버레이 클릭 시 드로어가 닫히던 버그 수정**: 포털로 렌더되는 모달(`useModalStore`)·`ConfirmOverlay` 위 클릭을 "바깥 클릭" 판정에서 제외 (`Sidebar`, `ConfirmOverlay`)
- **ESC 키로 드로어 닫기**: 드로어가 열려 있을 때 ESC로 닫힘 (모달이 떠 있으면 모달 닫기가 우선)
- **알림 → 프로필 이동 시 드로어 닫기**: 사용자 알림 클릭으로 프로필 페이지 이동 시 드로어 자동 닫힘

### 🎨 레이아웃 / 스타일
- **드로어 제목부와 헤더 높이 통일**(`h-16`): 하단 구분선 위치 정렬 (폰트 크기는 유지)
- **전체 화면 스크롤 문제 수정**: 루트를 `h-dvh overflow-hidden`으로 변경해 모바일 주소창(100vh) 문제 해결, 본문(`main`)만 스크롤되도록 함

### ✨ 기능 추가
- **개발 환경 임시 로그인 버튼**(`TmpLoginButton`): 로그인 모달에 개발용 로그인 버튼 추가 - 이전에 삭제했던 부분인데 개발환경에서 필요함을 느껴서 개발 환경에서만 뜨도록 추가하였습니다.
- **프로필 리캡 버튼 "준비중" 안내**: 리캡 기능 미구현 상태에서 버튼 클릭 시 `🚧 준비중!`이 둥실 떠오르는 안내 표시 (`float-up` 애니메이션 추가)

## 기타 참고 사항

- 리캡 "준비중" 안내 관련 코드는 정식 리캡 기능 구현 시 제거 대상이며, `⚠️ 리캡 기능 구현 이후 삭제 예정` 주석으로 마킹돼 있습니다.
- 드로어 바깥 클릭/ESC 처리는 "모달이 열려 있으면 모달 우선" 규칙을 따릅니다.

### 변경 파일
- `app/layout.tsx`, `app/globals.css`
- `components/sidebar/{Sidebar,Drawer}.tsx`
- `components/layout/Header.tsx`, `components/ConfirmOverlay.tsx`
- `components/noti/NotiDrawerContent.tsx`
- `components/profile/ProfileInfo/ProfileActionButton.tsx`
- `components/modals/LoginModal/**` (임시 로그인 버튼)

### 포함 커밋
- `fix: 화면 전체가 스크롤되던 문제 수정`
- `feat: 리캡 버튼 클릭 시 준비중 안내 표시 (임시)`
- `chore: 내 프로필 페이지 리캡 버튼 임시 비활성화`
- `feat: 드로어 ESC 닫기 및 알림 클릭 프로필 이동 시 닫기`
- `style: 드로어 제목부와 헤더 높이를 h-16으로 통일`
- `fix: 모달/오버레이 클릭 시 좌측 드로어가 닫히던 문제 수정`
- `feat: 개발 환경 임시 로그인 버튼 추가`
