### PR TITLE
[Style] 앱 전체 버튼 일관성 정리 (아이콘 · 색 · hover · 안내 문구)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -28,10 +28,23 @@
   }
 }
 
+/* ⚠️ 리캡 기능 구현 이후 삭제 예정 - 리캡 '준비중' 둥실 안내용 */
+@keyframes float-up {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(-24px);
+    opacity: 0;
+  }
+}
+
 @theme {
   --animate-slide-up: slide-up 0.3s ease-out;
   --animate-fade-in: fade-in 0.2s ease-out;
   --animate-slide-in-right: slide-in-right 0.3s ease-out;
+  --animate-float-up: float-up 1.8s ease-out forwards; /* ⚠️ 리캡 기능 구현 이후 삭제 예정 */
 
   --color-primary: #00214d;
   --color-accent-cyan: #00ebc7;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
         <NotiPollingGate />
 
         <ToastProvider>
-          <div className="flex h-screen">
+          <div className="flex h-dvh overflow-hidden">
             {/* 좌측 사이드바 (데스크탑 전용) */}
             <div className="hidden lg:flex h-full">
               <Sidebar />

--- a/apps/web/src/components/ConfirmOverlay.tsx
+++ b/apps/web/src/components/ConfirmOverlay.tsx
@@ -38,7 +38,7 @@ export default function ConfirmOverlay({
   if (!open) return null;
 
   const overlay = (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/30" onClick={onCancel}>
+    <div data-drawer-keep className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/30" onClick={onCancel}>
       <div
         ref={ref}
         className="w-[280px] bg-white border-2 border-primary rounded-lg shadow-[4px_4px_0px_0px_#00214D] p-4"

--- a/apps/web/src/components/archive/ArchiveViewHeader.tsx
+++ b/apps/web/src/components/archive/ArchiveViewHeader.tsx
@@ -1,6 +1,6 @@
 import { createNewPlaylist } from '@/api';
 import { usePlaylistRefreshStore } from '@/stores';
-import { PlusCircle } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { toast } from 'react-toastify';
 
 export default function ArchiveViewHeader() {
@@ -27,7 +27,7 @@ export default function ArchiveViewHeader() {
         className="mt-4 md:mt-0 flex items-center bg-primary text-white px-6 py-3 rounded-xl font-bold hover:bg-accent-pink hover:shadow-[4px_4px_0px_0px_#00EBC7] transition-all border-2 border-transparent hover:border-black"
         onClick={onCreateNewPlaylist}
       >
-        <PlusCircle className="w-5 h-5 mr-2" />
+        <Plus className="w-5 h-5 mr-2" />
         <span>즉시 추가하기</span>
       </button>
     </div>

--- a/apps/web/src/components/archive/ArchiveViewHeader.tsx
+++ b/apps/web/src/components/archive/ArchiveViewHeader.tsx
@@ -28,7 +28,7 @@ export default function ArchiveViewHeader() {
         onClick={onCreateNewPlaylist}
       >
         <Plus className="w-5 h-5 mr-2" />
-        <span>즉시 추가하기</span>
+        <span>플레이리스트 추가</span>
       </button>
     </div>
   );

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -23,7 +23,7 @@ export default function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-10 bg-white/95 backdrop-blur-sm border-b-2 border-primary px-6 py-4 flex items-center justify-between">
+    <header className="sticky top-0 z-10 bg-white/95 backdrop-blur-sm border-b-2 border-primary px-6 h-16 flex items-center justify-between">
       <button type="button" onClick={handleLogoClick} className="text-2xl font-black italic tracking-tighter text-primary uppercase">
         VIBR
       </button>

--- a/apps/web/src/components/layout/MobileBottomNav.tsx
+++ b/apps/web/src/components/layout/MobileBottomNav.tsx
@@ -21,7 +21,7 @@ type NavItem = {
 const navItems: NavItem[] = [
   { key: SidebarItemType.HOME, icon: Home, label: '홈' },
   { key: SidebarItemType.ARCHIVE, icon: Box, label: '보관함' },
-  { key: 'create', icon: Plus, label: '생성', special: true },
+  { key: 'create', icon: Plus, label: '추천', special: true },
   { key: SidebarItemType.SEARCH, icon: Search, label: '검색' },
   { key: SidebarItemType.PROFILE, icon: User, label: '프로필' },
 ];

--- a/apps/web/src/components/layout/MobileBottomNav.tsx
+++ b/apps/web/src/components/layout/MobileBottomNav.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useCallback, lazy, Suspense, useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { Home, Box, PlusCircle, Search, User } from 'lucide-react';
+import { Home, Box, Plus, Search, User } from 'lucide-react';
 
 import { SidebarItemType } from '@/types';
 import { useModalStore, MODAL_TYPES, useAuthStore } from '@/stores';
@@ -21,7 +21,7 @@ type NavItem = {
 const navItems: NavItem[] = [
   { key: SidebarItemType.HOME, icon: Home, label: '홈' },
   { key: SidebarItemType.ARCHIVE, icon: Box, label: '보관함' },
-  { key: 'create', icon: PlusCircle, label: '생성', special: true },
+  { key: 'create', icon: Plus, label: '생성', special: true },
   { key: SidebarItemType.SEARCH, icon: Search, label: '검색' },
   { key: SidebarItemType.PROFILE, icon: User, label: '프로필' },
 ];

--- a/apps/web/src/components/modals/LoginModal/LoginModal.tsx
+++ b/apps/web/src/components/modals/LoginModal/LoginModal.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useModalStore } from '@/stores/useModalStore';
 import { X } from 'lucide-react';
 import { getAuthErrorMessage } from '@/hooks/auth/client/authErrorMessage';
-import { GoogleLoginButton } from './loginButtons';
+import { GoogleLoginButton, TmpLoginButton } from './loginButtons';
 
 type LoginModalProps = {
   authError?: string;
@@ -38,6 +38,7 @@ export const LoginModal = () => {
           )}
           <GoogleLoginButton />
           {/* <SpotifyLoginButton /> */}
+          {process.env.NODE_ENV !== 'production' && <TmpLoginButton />}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/modals/LoginModal/loginButtons/TmpLoginButton.tsx
+++ b/apps/web/src/components/modals/LoginModal/loginButtons/TmpLoginButton.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useState } from 'react';
+import { tmpLogin } from '@/api/internal/auth';
+import { APP_ACCESS_TOKEN_STORAGE_KEY } from '@/constants/auth';
+
+// DEV 전용 시드 유저 (apps/api SEED_USERS와 동일)
+const DEV_USERS = [
+  { id: '019be163-4b37-76ad-aeb3-6986a3489de6', label: '테스트 사용자 1' },
+  { id: '019be163-4b3a-7619-a3cd-75302c5451e6', label: '테스트 사용자 2' },
+] as const;
+
+export const TmpLoginButton = () => {
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+
+  const handleTmpLogin = async (userId: string) => {
+    if (loadingId) return;
+    setLoadingId(userId);
+
+    try {
+      const appJwt = await tmpLogin(userId);
+      sessionStorage.setItem(APP_ACCESS_TOKEN_STORAGE_KEY, appJwt);
+      // Google 로그인과 동일하게 리로드로 인증 상태 재평가
+      window.location.assign('/');
+    } catch {
+      setLoadingId(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-dashed border-primary/30 pt-4">
+      <span className="text-xs font-bold text-secondary">DEV 임시 로그인</span>
+      {DEV_USERS.map((user) => (
+        <button
+          key={user.id}
+          type="button"
+          onClick={() => handleTmpLogin(user.id)}
+          disabled={loadingId !== null}
+          aria-busy={loadingId === user.id}
+          className="
+            w-full flex items-center justify-center gap-3
+            px-6 py-3 rounded-full font-bold text-sm
+            border border-dashed border-primary
+            bg-white text-primary
+            hover:bg-gray-50
+            active:scale-[0.98]
+            transition-all
+            disabled:opacity-60 disabled:cursor-not-allowed
+          "
+        >
+          {loadingId === user.id ? (
+            <>
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              로그인 중…
+            </>
+          ) : (
+            <>{user.label}로 로그인</>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/components/modals/LoginModal/loginButtons/index.ts
+++ b/apps/web/src/components/modals/LoginModal/loginButtons/index.ts
@@ -1,2 +1,3 @@
 export { GoogleLoginButton } from './GoogleLoginButton';
 export { SpotifyLoginButton } from './SpotifyLoginButton';
+export { TmpLoginButton } from './TmpLoginButton';

--- a/apps/web/src/components/noti/NotiDrawerContent.tsx
+++ b/apps/web/src/components/noti/NotiDrawerContent.tsx
@@ -8,7 +8,7 @@ import { MODAL_TYPES, useModalStore } from '@/stores';
 import { useRouter } from 'next/navigation';
 import { useNotiStore } from '@/stores/useNotiStore';
 
-export default function NotiDrawerContent() {
+export default function NotiDrawerContent({ onNavigate }: { onNavigate?: () => void }) {
   const openModal = useModalStore((s) => s.openModal);
   const router = useRouter();
 
@@ -30,6 +30,7 @@ export default function NotiDrawerContent() {
     }
 
     if (noti.relatedType === 'user') {
+      onNavigate?.();
       router.push(`/profile/${noti.relatedId}`);
       return;
     }

--- a/apps/web/src/components/player/MiniPlayerBar.tsx
+++ b/apps/web/src/components/player/MiniPlayerBar.tsx
@@ -133,7 +133,7 @@ export default function MiniPlayerBar({
           onClick={handlePrevClick}
           disabled={!canPrev}
           title={canPrev ? '이전 곡' : '이전 곡 없음'}
-          className="p-2 text-primary disabled:opacity-50 disabled:cursor-not-allowed"
+          className="p-2 text-primary rounded-full transition-colors hover:bg-gray-4 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <SkipBack className="w-5 h-5" />
         </button>
@@ -143,7 +143,7 @@ export default function MiniPlayerBar({
           onClick={handleTogglePlayClick}
           disabled={!isPlayable}
           title={!isPlayable ? '재생할 음악이 없습니다' : isPlaying ? '일시정지' : '재생'}
-          className="p-2 rounded-full bg-primary text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          className="p-2 rounded-full bg-primary text-white transition-all hover:shadow-[2px_2px_0px_0px_#00ebc7] disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isPlaying ? <Pause className="w-5 h-5" /> : <Play className="w-5 h-5 ml-0.5" />}
         </button>
@@ -153,7 +153,7 @@ export default function MiniPlayerBar({
           onClick={handleNextClick}
           disabled={!canNext}
           title={canNext ? '다음 곡' : '다음 곡 없음'}
-          className="p-2 text-primary disabled:opacity-50 disabled:cursor-not-allowed"
+          className="p-2 text-primary rounded-full transition-colors hover:bg-gray-4 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <SkipForward className="w-5 h-5" />
         </button>
@@ -168,12 +168,22 @@ export default function MiniPlayerBar({
           <ListPlus className="w-5 h-5" />
         </button>
 
-        <button type="button" onClick={handlePostClick} title={'추천 글 작성'} className="p-2 text-primary hidden sm:block">
-          <Plus className="w-5 h-5" />
+        <button
+          type="button"
+          onClick={handleSaveClick}
+          title={'보관함에 추가'}
+          className="p-2 rounded-lg border border-transparent text-primary transition-all hover:bg-white hover:border-accent-cyan hover:shadow-[2px_2px_0px_0px_#00ebc7] hidden sm:block"
+        >
+          <Box className="w-5 h-5" />
         </button>
 
-        <button type="button" onClick={handleSaveClick} title={'보관함에 추가'} className="p-2 text-primary hidden sm:block">
-          <Box className="w-5 h-5" />
+        <button
+          type="button"
+          onClick={handlePostClick}
+          title={'추천 글 작성'}
+          className="p-2 rounded-lg border border-transparent text-primary transition-all hover:bg-white hover:border-accent-pink hover:shadow-[2px_2px_0px_0px_#ff5470] hidden sm:block"
+        >
+          <Plus className="w-5 h-5" />
         </button>
       </div>
     </section>

--- a/apps/web/src/components/player/MiniPlayerBar.tsx
+++ b/apps/web/src/components/player/MiniPlayerBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { MusicResponseDto as Music } from '@repo/dto';
-import { FolderPlus, Pause, Play, PlusCircle, SkipBack, SkipForward, ListPlus } from 'lucide-react';
+import { Box, Pause, Play, Plus, SkipBack, SkipForward, ListPlus } from 'lucide-react';
 import { useModalStore, MODAL_TYPES } from '@/stores/useModalStore';
 import { useMusicActions } from '@/hooks';
 import { enqueueLog } from '@/utils';
@@ -169,11 +169,11 @@ export default function MiniPlayerBar({
         </button>
 
         <button type="button" onClick={handlePostClick} title={'컨텐츠 생성'} className="p-2 text-primary hidden sm:block">
-          <PlusCircle className="w-5 h-5" />
+          <Plus className="w-5 h-5" />
         </button>
 
         <button type="button" onClick={handleSaveClick} title={'보관함 선택 후 추가'} className="p-2 text-primary hidden sm:block">
-          <FolderPlus className="w-5 h-5" />
+          <Box className="w-5 h-5" />
         </button>
       </div>
     </section>

--- a/apps/web/src/components/player/MiniPlayerBar.tsx
+++ b/apps/web/src/components/player/MiniPlayerBar.tsx
@@ -103,7 +103,7 @@ export default function MiniPlayerBar({
     await addMusicToArchive(currentMusic);
   };
 
-  const queueTitle = isQueueOpen ? '재생목록 닫기' : '재생목록 열기';
+  const queueTitle = isQueueOpen ? '현재 재생목록 닫기' : '현재 재생목록 열기';
 
   return (
     <section className="relative z-20 flex lg:hidden h-full items-center gap-3 px-4 bg-white">
@@ -168,11 +168,11 @@ export default function MiniPlayerBar({
           <ListPlus className="w-5 h-5" />
         </button>
 
-        <button type="button" onClick={handlePostClick} title={'컨텐츠 생성'} className="p-2 text-primary hidden sm:block">
+        <button type="button" onClick={handlePostClick} title={'추천 글 작성'} className="p-2 text-primary hidden sm:block">
           <Plus className="w-5 h-5" />
         </button>
 
-        <button type="button" onClick={handleSaveClick} title={'보관함 선택 후 추가'} className="p-2 text-primary hidden sm:block">
+        <button type="button" onClick={handleSaveClick} title={'보관함에 추가'} className="p-2 text-primary hidden sm:block">
           <Box className="w-5 h-5" />
         </button>
       </div>

--- a/apps/web/src/components/player/QueueList.tsx
+++ b/apps/web/src/components/player/QueueList.tsx
@@ -101,7 +101,7 @@ export default function QueueList({ queue, currentMusicId, onClear, onRemove, on
             onClick={handleClearClick}
             disabled={isEmpty}
             title={isEmpty ? '큐가 비어있습니다' : '전체 비우기'}
-            className="flex items-center gap-1 px-3 py-2 rounded-md border-2 border-primary text-primary font-bold text-sm hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex items-center gap-1 px-3 py-2 rounded-md border-2 border-primary text-primary font-bold text-sm transition-all hover:bg-white enabled:hover:shadow-[2px_2px_0px_0px_#00ebc7] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <XCircle className="w-4 h-4" />
             Clear

--- a/apps/web/src/components/player/QueueList.tsx
+++ b/apps/web/src/components/player/QueueList.tsx
@@ -81,7 +81,7 @@ export default function QueueList({ queue, currentMusicId, onClear, onRemove, on
             onClick={handleArchive}
             disabled={isEmpty}
             title={'보관함 플레이리스트 저장'}
-            className="p-2 bg-white border-2 border-primary rounded-md  disabled:opacity-50 disabled:cursor-not-allowed"
+            className="p-2 bg-white border-2 border-primary rounded-md transition-all enabled:hover:shadow-[2px_2px_0px_0px_#00ebc7] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Box className="w-4 h-4" />
           </button>
@@ -91,7 +91,7 @@ export default function QueueList({ queue, currentMusicId, onClear, onRemove, on
             onClick={handleAdd}
             disabled={isEmpty}
             title={'새로운 컨텐츠 작성'}
-            className="p-2 bg-accent-pink text-white border-2 border-primary rounded-md  disabled:opacity-50 disabled:cursor-not-allowed"
+            className="p-2 bg-accent-pink text-white border-2 border-primary rounded-md transition-all enabled:hover:shadow-[2px_2px_0px_0px_#00ebc7] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Plus className="w-4 h-4" />
           </button>

--- a/apps/web/src/components/player/QueueList.tsx
+++ b/apps/web/src/components/player/QueueList.tsx
@@ -80,7 +80,7 @@ export default function QueueList({ queue, currentMusicId, onClear, onRemove, on
             type="button"
             onClick={handleArchive}
             disabled={isEmpty}
-            title={'보관함 플레이리스트 저장'}
+            title={'재생목록을 보관함에 추가'}
             className="p-2 bg-white border-2 border-primary rounded-md transition-all enabled:hover:shadow-[2px_2px_0px_0px_#00ebc7] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Box className="w-4 h-4" />
@@ -90,7 +90,7 @@ export default function QueueList({ queue, currentMusicId, onClear, onRemove, on
             type="button"
             onClick={handleAdd}
             disabled={isEmpty}
-            title={'새로운 컨텐츠 작성'}
+            title={'재생목록으로 추천 글 작성'}
             className="p-2 bg-accent-pink text-white border-2 border-primary rounded-md transition-all enabled:hover:shadow-[2px_2px_0px_0px_#00ebc7] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Plus className="w-4 h-4" />

--- a/apps/web/src/components/player/QueueList.tsx
+++ b/apps/web/src/components/player/QueueList.tsx
@@ -80,7 +80,7 @@ export default function QueueList({ queue, currentMusicId, onClear, onRemove, on
             type="button"
             onClick={handleArchive}
             disabled={isEmpty}
-            title={'재생목록을 보관함에 추가'}
+            title={'현재 재생목록을 보관함에 추가'}
             className="p-2 bg-white border-2 border-primary rounded-md transition-all enabled:hover:shadow-[2px_2px_0px_0px_#00ebc7] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Box className="w-4 h-4" />
@@ -90,7 +90,7 @@ export default function QueueList({ queue, currentMusicId, onClear, onRemove, on
             type="button"
             onClick={handleAdd}
             disabled={isEmpty}
-            title={'재생목록으로 추천 글 작성'}
+            title={'현재 재생목록으로 추천 글 작성'}
             className="p-2 bg-accent-pink text-white border-2 border-primary rounded-md transition-all enabled:hover:shadow-[2px_2px_0px_0px_#00ebc7] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Plus className="w-4 h-4" />

--- a/apps/web/src/components/player/nowPlaying/NowPlayingControlsStatic.tsx
+++ b/apps/web/src/components/player/nowPlaying/NowPlayingControlsStatic.tsx
@@ -59,7 +59,7 @@ function NowPlayingControlsStaticBase({
         disabled={!enabled}
         className={
           enabled
-            ? 'w-12 h-12 rounded-full bg-primary text-white flex items-center justify-center shadow-[3px_3px_0px_0px_#00ebc7]'
+            ? 'w-12 h-12 rounded-full bg-primary text-white flex items-center justify-center transition-all hover:shadow-[3px_3px_0px_0px_#00ebc7]'
             : 'w-12 h-12 rounded-full bg-gray-2 text-white flex items-center justify-center cursor-not-allowed'
         }
         title={isPlaying ? '일시정지' : '재생'}

--- a/apps/web/src/components/player/nowPlaying/NowPlayingControlsStatic.tsx
+++ b/apps/web/src/components/player/nowPlaying/NowPlayingControlsStatic.tsx
@@ -44,7 +44,11 @@ function NowPlayingControlsStaticBase({
         }}
         disabled={enabled && !canPrev}
         title={canPrev ? '이전 곡' : '이전 곡 없음'}
-        className={enabled ? 'text-primary disabled:opacity-50 disabled:cursor-not-allowed' : 'text-gray-2 cursor-not-allowed'}
+        className={
+          enabled
+            ? 'text-primary p-2 rounded-full transition-colors hover:bg-gray-4 disabled:opacity-50 disabled:cursor-not-allowed'
+            : 'text-gray-2 cursor-not-allowed'
+        }
       >
         <SkipBack className="w-6 h-6" />
       </button>
@@ -76,7 +80,11 @@ function NowPlayingControlsStaticBase({
         }}
         disabled={enabled && !canNext}
         title={canNext ? '다음 곡' : '다음 곡 없음'}
-        className={enabled ? 'text-primary disabled:opacity-50 disabled:cursor-not-allowed' : 'text-gray-2 cursor-not-allowed'}
+        className={
+          enabled
+            ? 'text-primary p-2 rounded-full transition-colors hover:bg-gray-4 disabled:opacity-50 disabled:cursor-not-allowed'
+            : 'text-gray-2 cursor-not-allowed'
+        }
       >
         <SkipForward className="w-6 h-6" />
       </button>

--- a/apps/web/src/components/player/nowPlaying/NowPlayingMetaActions.tsx
+++ b/apps/web/src/components/player/nowPlaying/NowPlayingMetaActions.tsx
@@ -55,7 +55,7 @@ function NowPlayingMetaActionsBase({ currentMusic, playError, onPost, onSave }: 
             className="flex items-center gap-1 px-3 py-1.5 rounded-full border-2 border-primary bg-accent-pink text-white font-bold text-xs cursor-pointer transition-all hover:shadow-[2px_2px_0px_0px_#00ebc7]"
           >
             <Plus className="w-4 h-4" />
-            게시
+            추천
           </button>
         </div>
       )}

--- a/apps/web/src/components/player/nowPlaying/NowPlayingMetaActions.tsx
+++ b/apps/web/src/components/player/nowPlaying/NowPlayingMetaActions.tsx
@@ -41,7 +41,7 @@ function NowPlayingMetaActionsBase({ currentMusic, playError, onPost, onSave }: 
           <button
             type="button"
             onClick={onSave}
-            title="보관함에 음악 추가"
+            title="보관함에 추가"
             className="flex items-center gap-1 px-3 py-1.5 rounded-full border-2 border-primary text-primary font-bold text-xs cursor-pointer transition-all hover:shadow-[2px_2px_0px_0px_#00ebc7]"
           >
             <Box className="w-4 h-4" />
@@ -51,7 +51,7 @@ function NowPlayingMetaActionsBase({ currentMusic, playError, onPost, onSave }: 
           <button
             type="button"
             onClick={onPost}
-            title="컨텐츠 작성"
+            title="추천 글 작성"
             className="flex items-center gap-1 px-3 py-1.5 rounded-full border-2 border-primary bg-accent-pink text-white font-bold text-xs cursor-pointer transition-all hover:shadow-[2px_2px_0px_0px_#00ebc7]"
           >
             <Plus className="w-4 h-4" />

--- a/apps/web/src/components/player/nowPlaying/NowPlayingMetaActions.tsx
+++ b/apps/web/src/components/player/nowPlaying/NowPlayingMetaActions.tsx
@@ -2,7 +2,7 @@
 
 import type { MusicResponseDto as Music } from '@repo/dto';
 import React, { memo } from 'react';
-import { PlusCircle, FolderPlus } from 'lucide-react';
+import { Box, Plus } from 'lucide-react';
 import { TickerText } from '@/components';
 
 type Props = {
@@ -40,22 +40,22 @@ function NowPlayingMetaActionsBase({ currentMusic, playError, onPost, onSave }: 
         <div className="flex items-center justify-center gap-2 mb-3">
           <button
             type="button"
-            onClick={onPost}
-            title="컨텐츠 작성"
-            className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-primary text-white font-bold text-xs opacity-50 cursor-not-allowed"
+            onClick={onSave}
+            title="보관함에 음악 추가"
+            className="flex items-center gap-1 px-3 py-1.5 rounded-full border-2 border-primary text-primary font-bold text-xs cursor-pointer transition-all hover:shadow-[2px_2px_0px_0px_#00ebc7]"
           >
-            <PlusCircle className="w-4 h-4" />
-            게시
+            <Box className="w-4 h-4" />
+            저장
           </button>
 
           <button
             type="button"
-            onClick={onSave}
-            title="보관함에 음악 추가"
-            className="flex items-center gap-1 px-3 py-1.5 rounded-full border-2 border-primary text-primary font-bold text-xs opacity-50 cursor-not-allowed"
+            onClick={onPost}
+            title="컨텐츠 작성"
+            className="flex items-center gap-1 px-3 py-1.5 rounded-full border-2 border-primary bg-accent-pink text-white font-bold text-xs cursor-pointer transition-all hover:shadow-[2px_2px_0px_0px_#00ebc7]"
           >
-            <FolderPlus className="w-4 h-4" />
-            저장
+            <Plus className="w-4 h-4" />
+            게시
           </button>
         </div>
       )}

--- a/apps/web/src/components/post/partials/PostMedia.tsx
+++ b/apps/web/src/components/post/partials/PostMedia.tsx
@@ -26,7 +26,8 @@ type Props = {
 const stylesByVariant: Record<Variant, { container: string; playBtn: string; infoBox: string; navBtn: string }> = {
   card: {
     container: 'relative group w-full aspect-square overflow-hidden xs:rounded-md mb-4 bg-gray-100',
-    playBtn: 'w-12 aspect-square rounded-full bg-primary text-white flex items-center justify-center shadow-[2px_2px_0px_0px_#00ebc7]',
+    playBtn:
+      'w-12 aspect-square rounded-full bg-primary text-white flex items-center justify-center transition-all hover:shadow-[2px_2px_0px_0px_#00ebc7]',
     infoBox:
       'absolute max-w-4/5 bottom-4 left-4 bg-white/90 backdrop-blur-sm px-4 py-2 rounded-lg border-2 border-primary shadow-[4px_4px_0px_0px_#FDE24F]',
     navBtn:
@@ -36,7 +37,7 @@ const stylesByVariant: Record<Variant, { container: string; playBtn: string; inf
   modal: {
     container: 'w-full aspect-[7/4] md:aspect-[7/3] md:flex-1 bg-gray-4 relative group overflow-hidden',
     playBtn:
-      'w-10 md:w-12 aspect-square rounded-full bg-primary text-white flex items-center justify-center shadow-[3px_3px_0px_0px_#00ebc7] hover:scale-105 transition-transform',
+      'w-10 md:w-12 aspect-square rounded-full bg-primary text-white flex items-center justify-center transition-all hover:scale-105 hover:shadow-[3px_3px_0px_0px_#00ebc7]',
     infoBox:
       'absolute max-w-4/5 bottom-3 left-3 md:bottom-6 md:left-6 bg-white/90 backdrop-blur-sm px-2.5 py-1.5 sm:px-5 sm:py-3 rounded-xl border-2 border-primary shadow-[3px_3px_0px_0px_#FDE24F] md:shadow-[6px_6px_0px_0px_#FDE24F]',
     navBtn:

--- a/apps/web/src/components/profile/ProfileInfo/ProfileActionButton.tsx
+++ b/apps/web/src/components/profile/ProfileInfo/ProfileActionButton.tsx
@@ -43,14 +43,16 @@ export default function ProfileActionButton({
 
   // 내 프로필이면 -> 프로필 페이지에서는 리캡 생성 버튼, 모달에서는 버튼 필요 x
   if (isMyProfile) {
-    return renderIn === 'modal' ? null : (
-      <button
-        title="프로필 리캡 생성"
-        className="text-sm xs:text-base px-4 xs:px-6 py-2 rounded-full bg-accent-yellow/90 border-2 border-primary text-primary font-bold hover:bg-accent-yellow hover:shadow-[2px_2px_0px_0px_#00214D] transition-all"
-      >
-        Recap
-      </button>
-    );
+    // 리캡 생성 버튼 임시 비활성화 (주석 처리)
+    // return renderIn === 'modal' ? null : (
+    //   <button
+    //     title="프로필 리캡 생성"
+    //     className="text-sm xs:text-base px-4 xs:px-6 py-2 rounded-full bg-accent-yellow/90 border-2 border-primary text-primary font-bold hover:bg-accent-yellow hover:shadow-[2px_2px_0px_0px_#00214D] transition-all"
+    //   >
+    //     Recap
+    //   </button>
+    // );
+    return null;
   }
 
   // isFollowing === true -> [팔로잉] 버튼, 누르면 팔로우 취소 요청

--- a/apps/web/src/components/profile/ProfileInfo/ProfileActionButton.tsx
+++ b/apps/web/src/components/profile/ProfileInfo/ProfileActionButton.tsx
@@ -23,6 +23,13 @@ export default function ProfileActionButton({
 }: ProfileActionButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
 
+  // ⚠️ 리캡 기능 구현 이후 삭제 예정 - '준비중' 안내 임시 처리
+  const [showRecapHint, setShowRecapHint] = useState(false);
+  const handleRecapClick = useCallback(() => {
+    setShowRecapHint(true);
+    setTimeout(() => setShowRecapHint(false), 1800);
+  }, []);
+
   const isLoggedIn = !!loggedInUserId;
   const isMyProfile = loggedInUserId === profileUserId;
 
@@ -43,16 +50,24 @@ export default function ProfileActionButton({
 
   // 내 프로필이면 -> 프로필 페이지에서는 리캡 생성 버튼, 모달에서는 버튼 필요 x
   if (isMyProfile) {
-    // 리캡 생성 버튼 임시 비활성화 (주석 처리)
-    // return renderIn === 'modal' ? null : (
-    //   <button
-    //     title="프로필 리캡 생성"
-    //     className="text-sm xs:text-base px-4 xs:px-6 py-2 rounded-full bg-accent-yellow/90 border-2 border-primary text-primary font-bold hover:bg-accent-yellow hover:shadow-[2px_2px_0px_0px_#00214D] transition-all"
-    //   >
-    //     Recap
-    //   </button>
-    // );
-    return null;
+    return renderIn === 'modal' ? null : (
+      <div className="relative">
+        {/* ⚠️ 리캡 기능 구현 이후 삭제 예정 - 클릭 시 '준비중' 둥실 안내 */}
+        {showRecapHint && (
+          // 바깥: 가로 중앙 정렬 / 안쪽: 위로 둥실 떠오르며 페이드아웃 (transform 충돌 방지)
+          <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1">
+            <span className="block whitespace-nowrap text-sm font-bold text-primary animate-float-up">🚧 준비중!</span>
+          </span>
+        )}
+        <button
+          onClick={handleRecapClick} // ⚠️ 리캡 기능 구현 이후 실제 리캡 생성 핸들러로 교체
+          title="프로필 리캡 생성"
+          className="text-sm xs:text-base px-4 xs:px-6 py-2 rounded-full bg-accent-yellow/90 border-2 border-primary text-primary font-bold hover:bg-accent-yellow hover:shadow-[2px_2px_0px_0px_#00214D] transition-all"
+        >
+          Recap
+        </button>
+      </div>
+    );
   }
 
   // isFollowing === true -> [팔로잉] 버튼, 누르면 팔로우 취소 요청

--- a/apps/web/src/components/search/TrackItem.tsx
+++ b/apps/web/src/components/search/TrackItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Play, Plus } from 'lucide-react';
+import { Box, Plus } from 'lucide-react';
 
 import { useModalStore, MODAL_TYPES } from '@/stores';
 import { useMusicActions } from '@/hooks';
@@ -43,7 +43,7 @@ export default function TrackItem({ mode, item, isAuthenticated }: TrackItemProp
   const isVideo = mode === 'video';
 
   return (
-    <div className="w-full flex items-center p-3 rounded-xl hover:bg-gray-4 transition-colors">
+    <div onClick={handlePlayClick} title="재생" className="w-full flex items-center p-3 rounded-xl cursor-pointer hover:bg-gray-4 transition-colors">
       <div
         className={`${isVideo ? 'h-14 aspect-video' : 'h-12 aspect-square'} mr-4 shrink-0 rounded-lg overflow-hidden border border-gray-3 bg-gray-4`}
       >
@@ -58,18 +58,12 @@ export default function TrackItem({ mode, item, isAuthenticated }: TrackItemProp
       <div className="flex items-center gap-2 ml-3">
         <button
           type="button"
-          onClick={handlePlayClick}
-          title="재생"
-          className="p-2 rounded-lg border border-gray-3 bg-white text-primary hover:bg-gray-4"
-        >
-          <Play className="w-4 h-4" />
-        </button>
-
-        <button
-          type="button"
-          onClick={handleArchiveClick}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleArchiveClick();
+          }}
           title="보관함 선택 추가"
-          className="p-2 rounded-lg border border-gray-3 bg-white text-primary hover:bg-gray-4
+          className="p-2 rounded-lg border border-gray-3 text-primary transition-all hover:bg-white hover:shadow-[2px_2px_0px_0px_#00ebc7]
                      disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Box className="w-4 h-4" />
@@ -77,9 +71,12 @@ export default function TrackItem({ mode, item, isAuthenticated }: TrackItemProp
 
         <button
           type="button"
-          onClick={handleWriteClick}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleWriteClick();
+          }}
           title="컨텐츠 작성"
-          className="p-2 rounded-lg border border-gray-3 bg-white text-primary hover:bg-gray-4
+          className="p-2 rounded-lg border border-gray-3 text-primary transition-all hover:bg-white hover:shadow-[2px_2px_0px_0px_#00ebc7]
                      disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Plus className="w-4 h-4" />

--- a/apps/web/src/components/search/TrackItem.tsx
+++ b/apps/web/src/components/search/TrackItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Play, PlusCircle } from 'lucide-react';
+import { Box, Play, Plus } from 'lucide-react';
 
 import { useModalStore, MODAL_TYPES } from '@/stores';
 import { useMusicActions } from '@/hooks';
@@ -82,7 +82,7 @@ export default function TrackItem({ mode, item, isAuthenticated }: TrackItemProp
           className="p-2 rounded-lg border border-gray-3 bg-white text-primary hover:bg-gray-4
                      disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          <PlusCircle className="w-4 h-4" />
+          <Plus className="w-4 h-4" />
         </button>
       </div>
     </div>

--- a/apps/web/src/components/search/TrackItem.tsx
+++ b/apps/web/src/components/search/TrackItem.tsx
@@ -62,7 +62,7 @@ export default function TrackItem({ mode, item, isAuthenticated }: TrackItemProp
             e.stopPropagation();
             handleArchiveClick();
           }}
-          title="보관함 선택 추가"
+          title="보관함에 추가"
           className="p-2 rounded-lg border border-gray-3 text-primary transition-all hover:bg-white hover:shadow-[2px_2px_0px_0px_#00ebc7]
                      disabled:opacity-50 disabled:cursor-not-allowed"
         >
@@ -75,7 +75,7 @@ export default function TrackItem({ mode, item, isAuthenticated }: TrackItemProp
             e.stopPropagation();
             handleWriteClick();
           }}
-          title="컨텐츠 작성"
+          title="추천 글 작성"
           className="p-2 rounded-lg border border-gray-3 text-primary transition-all hover:bg-white hover:shadow-[2px_2px_0px_0px_#00ebc7]
                      disabled:opacity-50 disabled:cursor-not-allowed"
         >

--- a/apps/web/src/components/sidebar/Drawer.tsx
+++ b/apps/web/src/components/sidebar/Drawer.tsx
@@ -28,7 +28,8 @@ export default function Drawer({ isOpen, isSidebarExpanded, title, children, loa
       `}
     >
       {title && (
-        <div className="px-6 py-4 border-b-2 border-primary flex-shrink-0">
+        // 높이를 중앙 Header(h-16)와 맞춰 하단 구분선 위치를 정렬 (폰트 크기는 유지)
+        <div className="px-6 h-16 flex items-center border-b-2 border-primary flex-shrink-0">
           <h2 className="text-xl font-black text-primary">{title}</h2>
         </div>
       )}

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -220,7 +220,7 @@ export default function Sidebar() {
               onClick={handleOpenWriteModal}
               className={`
               flex items-center p-3 rounded-xl transition-all duration-150 mb-2
-              bg-primary text-white hover:bg-secondary hover:shadow-[2px_2px_0px_0px_#00ebc7]
+              bg-primary text-white hover:bg-accent-pink hover:shadow-[2px_2px_0px_0px_#00ebc7]
               ${!isExpanded && 'justify-center'}
             `}
               title="추천"

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 import { useMemo, useState, lazy, useEffect, useRef, useCallback } from 'react';
-import { LogIn, LogOut, Menu, PlusCircle } from 'lucide-react';
+import { LogIn, LogOut, Menu, Plus } from 'lucide-react';
 
 import { menuItems, SIDEBAR_WIDTH_EXPANDED, SIDEBAR_WIDTH_SHRINKED } from '@/constants';
 import { drawerTypes, SidebarItemType, type SidebarItemTypeValues } from '@/types';
@@ -225,7 +225,7 @@ export default function Sidebar() {
             `}
               title="생성"
             >
-              <PlusCircle className="sidebar-icon" />
+              <Plus className="sidebar-icon" />
               {isExpanded && <span className="ml-4 font-bold text-sm md:text-base whitespace-nowrap overflow-hidden">생성</span>}
             </button>
           </div>

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -223,10 +223,10 @@ export default function Sidebar() {
               bg-primary text-white hover:bg-secondary hover:shadow-[2px_2px_0px_0px_#00ebc7]
               ${!isExpanded && 'justify-center'}
             `}
-              title="생성"
+              title="추천"
             >
               <Plus className="sidebar-icon" />
-              {isExpanded && <span className="ml-4 font-bold text-sm md:text-base whitespace-nowrap overflow-hidden">생성</span>}
+              {isExpanded && <span className="ml-4 font-bold text-sm md:text-base whitespace-nowrap overflow-hidden">추천</span>}
             </button>
           </div>
         </div>

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -155,6 +155,18 @@ export default function Sidebar() {
     };
   }, [activeDrawer, handleCloseDrawer]);
 
+  useEffect(() => {
+    // ESC 키로 열린 드로어 닫기 (모달이 열려 있으면 모달 닫기가 우선)
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      if (useModalStore.getState().isOpen) return;
+      if (activeDrawer) handleCloseDrawer();
+    };
+
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [activeDrawer, handleCloseDrawer]);
+
   return (
     <div className="flex h-full relative z-30" ref={sidebarRef}>
       {/* 메뉴 버튼 영역 */}
@@ -243,7 +255,7 @@ export default function Sidebar() {
 
       {/* 2. 알림 */}
       <Drawer isOpen={isNotificationOpen} isSidebarExpanded={isExpanded} title="알림">
-        <NotiDrawerContent />
+        <NotiDrawerContent onNavigate={handleCloseDrawer} />
       </Drawer>
     </div>
   );

--- a/apps/web/src/components/sidebar/Sidebar.tsx
+++ b/apps/web/src/components/sidebar/Sidebar.tsx
@@ -136,7 +136,14 @@ export default function Sidebar() {
   useEffect(() => {
     // 외부 영역 클릭 여부 판단 후 열린 드로어가 있다면 닫기
     const handleClickOutside = (event: MouseEvent) => {
-      if (sidebarRef.current && !sidebarRef.current.contains(event.target as Node) && activeDrawer) {
+      const target = event.target as HTMLElement;
+
+      // 포털로 띄워진 모달/오버레이 위 클릭은 바깥 클릭으로 보지 않음
+      // (sidebarRef DOM 밖이라 그냥 두면 드로어가 닫혀버림)
+      if (useModalStore.getState().isOpen) return;
+      if (target.closest('[data-drawer-keep]')) return;
+
+      if (sidebarRef.current && !sidebarRef.current.contains(target) && activeDrawer) {
         handleCloseDrawer();
       }
     };


### PR DESCRIPTION
## 🚀 PR 개요

저장/추천(글 작성)/재생 등 앱 곳곳의 액션 버튼이 아이콘·색·hover·문구가 제각각이라,
RightPanel(NowPlaying·재생목록)을 기준으로 앱 전체 버튼을 일관되게 정리했습니다.

## 🔗 관련 이슈

이슈 작성 없이 작업했습니다.

## 개선하고자 했던 점

- **RightPannel**
  <img width="220" height="396" alt="image" src="https://github.com/user-attachments/assets/f08e63da-243d-4d34-a4cc-eb70f10f0a32" />
  - 위 스크린 샷에 표시된 **NowPlaying** 컴포넌트의 게시/저장 버튼과 **QueueList**의 게시/저장 버튼의 순서, 색깔 등이 맞지 않고 **NowPlaying** 컴포넌트의 버튼은 비활성화된것처럼 흐리게 표현되어있음.
  - 같은 게시글 작성, 보관함 저장 기능을 하는 버튼이지만 아이콘도 다름
- 사용되는 표현이 다른 점
  <img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/6171c75d-0dab-4608-84f9-b646865ee888" />
  <img width="190" height="90" alt="image" src="https://github.com/user-attachments/assets/a9602768-0df1-4e3b-8d7c-75f825383fa6" />

  - 위의 RightPannel에서 마우스를 올리면 표시되는 툴팁 설명에는 **"컨텐츠 작성"** 이라고 되어있고 Sidebar의 버튼은 **"생성"** 이라고 되어있는 등 메시지의 일관성이 떨어짐
  

## 🔍 작업 내용

### **RightPannel** 의 버튼들의 일관성을 챙겼습니다.
- 아이콘 - 저장(보관함) = `Box`, 추천(글 작성) = `Plus` 로 앱 전체 통일
- 색깔 - 추천은 위아래 동일하게 'accent-pink'로 채움
  <img width="200" height="428" alt="image" src="https://github.com/user-attachments/assets/a8bc2b6d-bade-44ee-bf50-0a29ddcd88b7" />

### Hover 효과 정리
- 재생 버튼들(NowPlaying·게시글 카드/모달): cyan 색의 그림자가 상시 표시 돼있었는데 hover 시에만 표시되도록 수정했습니다. (게시글의 재생 버튼에도 적용했습니다.)
  - hover X: <img width="232" height="84" alt="스크린샷 2026-06-05 오후 10 23 06" src="https://github.com/user-attachments/assets/96f40cbc-eaab-4733-8f32-9d1cc32bf266" />
  - hover O: <img width="230" height="84" alt="스크린샷 2026-06-05 오후 10 23 12" src="https://github.com/user-attachments/assets/a85b9bf9-8e03-49d1-a48d-b43783032278" />

- RightPannel의 현재 재생목록 Clear 버튼: hover 시 cyan 섀도우 추가
  <img width="99" height="67" alt="image" src="https://github.com/user-attachments/assets/a25e1b9a-4312-4828-9cd8-1b0c58d6d1db" />

- 미니플레이어 컨트롤(이전/다음/재생/재생목록)·NowPlaying 이전/다음: hover 피드백 추가
- 미니플레이어 보관/추천 버튼: hover 시 cyan(보관)/pink(추천) 얇은 테두리 + 하드 섀도우 (아래 이미지의 아래 미니플레이어바 부분 참고)
  <img width="722" height="227" alt="image" src="https://github.com/user-attachments/assets/baefb11d-a5f6-4d1c-b482-4f344dde321c" />
  
- 사이드바 추천 버튼: hover 색 pink로 (보관함 '플레이리스트 추가' 버튼과 동일) (아래는 마우스 hover 시 모습)
  <img width="263" height="155" alt="image" src="https://github.com/user-attachments/assets/7edccb7f-e8a2-4efe-bd8d-074962efba9b" />

### 동작 변경
- 검색 결과: 별도 재생 버튼 제거 → 하나의 항목에 버튼의 개수를 두 개로 줄이고 항목 자체를 클릭하면 재생되도록 해서 직관적인 ux를 제공할 있도록 개선했습니다.
  - before
    <img width="229" height="240" alt="image" src="https://github.com/user-attachments/assets/18e0cd5e-99c2-4c2f-ac34-080ff8e244e8" />
  - after
    <img width="248" height="320" alt="스크린샷 2026-06-05 오후 10 37 39" src="https://github.com/user-attachments/assets/a9dd8426-1e98-4b0d-8297-930572d77234" />

### 기타

보관함 페이지의 "즉시 추가하기" 라고 되어있는 버튼을 "플레이리스트 추가"로 라벨 변경하였습니다.

## 🙋 팀 의견 요청
- **작성 버튼 라벨을 "추천"으로 정했는데 적절할까요?**
  - 현재 Sidebar에서 게시글 작성 버튼의 라벨이 "생성"으로 되어있고, NowPlaying 컴포넌트의 버튼의 라벨은 "게시"라고 되어있습니다.
  - 하나로 통일하고자 고민하다가 "추천"으로 바꾸었는데 이게 더 좋다는 확신이 없어서 팀원 분들의 의견이 필요합니다.
  - 다른 후보로는 "작성", "글쓰기" 등이 있었습니다.
